### PR TITLE
Reduce test runtime by mocking logo

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,7 +1,19 @@
+# -*- coding: utf-8 -*-
+"""
+@author: jmbr
+"""
+
+import streamlit as st
 import os
 import pytest
+
 
 @pytest.fixture
 def test_dir():
     """Returns the path to the test data directory."""
     return os.path.dirname(__file__)
+
+
+@pytest.fixture(autouse=True)
+def skip_logo(monkeypatch):
+    monkeypatch.setattr(st, "logo", lambda *args, **kwargs: None)


### PR DESCRIPTION
d5a83b78a87be6d804712999ee0330cbab985fb4, which only added the cadet logo, significantly increased the ci runtime

Caching the image [61496a5](https://github.com/cadet/CADET-Equations/pull/23/commits/61496a5e12f29df70dca7fb04ccd2c0f596db21c) seems to not fix the issue ..