### PR TITLE
Fix equation overlap using aligned environments and refined CSS

### DIFF
--- a/pages/Documentation.py
+++ b/pages/Documentation.py
@@ -12,7 +12,6 @@ st.logo("images/logo_CADET.png", size="large", link=None, icon_image=None)
 st.set_page_config(
     page_title="Documentation",
     page_icon=":material/docs:",
-    layout="wide",
 )
 
 # Helper funciton to use citations in standard markdown (streamlit)

--- a/src/equations.py
+++ b/src/equations.py
@@ -463,8 +463,8 @@ def particle_transport_radial(geometry: str, has_surfDiff: bool, has_binding: bo
 \begin{align}    
 \varepsilon^{\mathrm{p}}_{j} \frac{\partial c^{\p}_{j,i}}{\partial t}
 &=
-\varepsilon^{\mathrm{p}}_{j} \frac{1}{r} \frac{\partial }{\partial r} \left( r D_{j,i}^{\mathrm{p}} \frac{\partial c^{\mathrm{p}}_{j,i}}{\partial r} \right) - \left( 1 - \varepsilon^{\mathrm{p}}_{j} \right) f^{\mathrm{bind}}_{j,i}\left( \vec{c}^{\mathrm{p}}, \vec{c}^{\mathrm{s}} \right), \\
-     \left( 1 - \varepsilon^{\mathrm{p}}_{j} \right) \frac{\partial c^{\mathrm{s}}_{j,i}}{\partial t}
+\varepsilon^{\mathrm{p}}_{j} \frac{1}{r} \frac{\partial }{\partial r} \left( r D_{j,i}^{\p} \frac{\partial c^{\p}_{j,i}}{\partial r} \right) - \left( 1 - \varepsilon^{\mathrm{p}}_{j} \right) f^{\mathrm{bind}}_{j,i}\left( \vec{c}^{\p}, \vec{c}^{\s} \right), \\
+     \left( 1 - \varepsilon^{\mathrm{p}}_{j} \right) \frac{\partial c^{\s}_{j,i}}{\partial t}
 &=
 """ + surfDiffTerm + r"""\left( 1 - \varepsilon^{\mathrm{p}}_{j} \right) f^{\mathrm{bind}}_{j,i}\left( \vec{c}^{\p}, \vec{c}^{\s} \right).
 \end{align}
@@ -478,8 +478,8 @@ def particle_transport_radial(geometry: str, has_surfDiff: bool, has_binding: bo
 \begin{align}    
 \varepsilon^{\mathrm{p}}_{j} \frac{\partial c^{\p}_{j,i}}{\partial t}
 &=
-\varepsilon^{\mathrm{p}}_{j} \frac{\partial }{\partial r} \left( D_{j,i}^{\mathrm{p}} \frac{\partial c^{\mathrm{p}}_{j,i}}{\partial r} \right) - \left( 1 - \varepsilon^{\mathrm{p}}_{j} \right) f^{\mathrm{bind}}_{j,i}\left( \vec{c}^{\mathrm{p}}, \vec{c}^{\mathrm{s}} \right), \\
-     \left( 1 - \varepsilon^{\mathrm{p}}_{j} \right) \frac{\partial c^{\mathrm{s}}_{j,i}}{\partial t}
+\varepsilon^{\mathrm{p}}_{j} \frac{\partial }{\partial r} \left( D_{j,i}^{\p} \frac{\partial c^{\p}_{j,i}}{\partial r} \right) - \left( 1 - \varepsilon^{\mathrm{p}}_{j} \right) f^{\mathrm{bind}}_{j,i}\left( \vec{c}^{\p}, \vec{c}^{\s} \right), \\
+     \left( 1 - \varepsilon^{\mathrm{p}}_{j} \right) \frac{\partial c^{\s}_{j,i}}{\partial t}
 &=
 """ + surfDiffTerm + r"""\left( 1 - \varepsilon^{\mathrm{p}}_{j} \right) f^{\mathrm{bind}}_{j,i}\left( \vec{c}^{\p}, \vec{c}^{\s} \right).
 \end{align}


### PR DESCRIPTION
fix to https://github.com/cadet/CADET-Equations/issues/34
