### PR TITLE
Add unit tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -3,5 +3,6 @@ pythonpath = .
 markers =
     debug: Marks tests manually specified for debugging
     ci: Marks continuous integration tests
+    unit_test: Marks unit tests
     reference: Marks reference solution tests
     all_config_runs: Marks all tests that check if configurations work fine

--- a/test/test_equations.py
+++ b/test/test_equations.py
@@ -1,0 +1,543 @@
+# -*- coding: utf-8 -*-
+"""
+Unit tests for src/equations.py.
+Each function is tested in isolation with relevant parameter combinations.
+"""
+
+import pytest
+from unittest.mock import MagicMock
+from src import equations as eq
+
+
+# %% Helpers
+
+def _make_particle(**overrides):
+    """Create a minimal Particle-like mock object.
+
+    Avoids importing the Streamlit-dependent Particle dataclass from
+    Equation-Generator.py while providing the attributes that equation
+    functions expect.
+    """
+    defaults = dict(
+        geometry="Sphere",
+        resolution="1D",
+        has_core=False,
+        has_binding=True,
+        req_binding=False,
+        has_mult_bnd_states=False,
+        has_surfDiff=False,
+        nonlimiting_filmDiff=False,
+        surface_volume_ratio=3,
+        interstitial_volume_resolution="1D",
+        single_partype=True,
+        PTD=False,
+    )
+    defaults.update(overrides)
+    return MagicMock(**defaults)
+
+
+# %% HRM_asmpt
+
+@pytest.mark.ci
+@pytest.mark.parametrize("column_resolution, N_p, has_binding, expected_keyword", [
+    ("0D (Homogeneous Tank)", 0, False, "tank"),
+    ("1D (axial coordinate)", 0, False, "column"),
+    ("1D (axial coordinate)", 1, True, "spherical"),
+    ("1D (axial coordinate)", 0, False, "no solid phase"),
+])
+def test_HRM_asmpt_device_and_particle_text(column_resolution, N_p, has_binding, expected_keyword):
+    """Verify that HRM assumptions adapt wording to device type and particle presence."""
+    result = eq.HRM_asmpt(N_p=N_p, nonlimiting_filmDiff=False,
+                          has_binding=has_binding, has_surfDiff=False,
+                          column_resolution=column_resolution)
+    combined = " ".join(result)
+    assert expected_keyword in combined
+
+
+@pytest.mark.ci
+def test_HRM_asmpt_binding_toggle():
+    """Binding-related assumptions should only appear when has_binding is True."""
+    with_bnd = eq.HRM_asmpt(N_p=1, nonlimiting_filmDiff=False,
+                             has_binding=True, has_surfDiff=False,
+                             column_resolution="1D (axial coordinate)")
+    without_bnd = eq.HRM_asmpt(N_p=1, nonlimiting_filmDiff=False,
+                                has_binding=False, has_surfDiff=False,
+                                column_resolution="1D (axial coordinate)")
+    assert "binding model" in " ".join(with_bnd)
+    assert "binding model" not in " ".join(without_bnd)
+
+
+@pytest.mark.ci
+def test_HRM_asmpt_filters_empty_strings():
+    """Empty assumption strings resulting from disabled options should be removed."""
+    result = eq.HRM_asmpt(N_p=0, nonlimiting_filmDiff=False,
+                          has_binding=False, has_surfDiff=False,
+                          column_resolution="1D (axial coordinate)")
+    assert "" not in result
+
+
+# %% Interstitial volume continuum assumptions
+
+@pytest.mark.ci
+@pytest.mark.parametrize("resolution, expected_keyword", [
+    ("3D", "continuum"),
+    ("2D", "radially symmetric"),
+    ("1D", "radially symmetric and homogeneous"),
+    ("0D", "spatially homogeneous"),
+])
+def test_int_vol_continuum_asmpt_per_resolution(resolution, expected_keyword):
+    """Each resolution should produce its characteristic assumption text."""
+    result = eq.int_vol_continuum_asmpt(resolution, N_p=1, nonlimiting_filmDiff=False)
+    combined = " ".join(result)
+    assert expected_keyword in combined
+
+
+@pytest.mark.ci
+@pytest.mark.parametrize("N_p, expected_keyword", [
+    (0, "tank"),
+    (1, "interstitial volume"),
+])
+def test_int_vol_0D_volume_naming(N_p, expected_keyword):
+    """0D assumption text refers to 'tank' without particles and 'interstitial volume' with."""
+    result = eq.int_vol_0DContinuum_asmpt(N_p=N_p, nonlimiting_filmDiff=False)
+    combined = " ".join(result)
+    assert expected_keyword in combined
+
+
+@pytest.mark.ci
+def test_int_vol_3D_multiple_particle_types():
+    """Multiple particle types (N_p > 1) should mention representative radii."""
+    result = eq.int_vol_3DContinuum_asmpt(N_p=2, nonlimiting_filmDiff=False)
+    combined = " ".join(result)
+    assert "N^{\\mathrm{p}}" in combined
+
+
+# %% Particle assumptions
+
+@pytest.mark.ci
+def test_particle_asmpts_base():
+    """Base particle assumptions should reference the outer particle surface."""
+    result = eq.particle_asmpts()
+    assert len(result) == 1
+    assert "outer particle surface" in result[0]
+
+
+@pytest.mark.ci
+@pytest.mark.parametrize("has_surfDiff, expected_keyword", [
+    (True, "surface diffusion"),
+    (False, "no surface diffusion"),
+])
+def test_particle_1D_surfDiff_toggle(has_surfDiff, expected_keyword):
+    """1D particle assumptions should reflect whether surface diffusion is active."""
+    result = eq.particle_1D_asmpt(has_surfDiff=has_surfDiff)
+    combined = " ".join(result)
+    assert expected_keyword in combined
+
+
+@pytest.mark.ci
+def test_particle_0D_infinite_diffusion():
+    """0D particles should state that diffusion is infinitely fast."""
+    result = eq.particle_0D_asmpt()
+    assert "infinitely fast" in " ".join(result)
+
+
+@pytest.mark.ci
+@pytest.mark.parametrize("resolution, has_surfDiff", [
+    ("0D", False),
+    ("1D", True),
+    ("1D", False),
+])
+def test_particle_asmpt_router(resolution, has_surfDiff):
+    """The router function should delegate to the correct resolution-specific function."""
+    result = eq.particle_asmpt(resolution, has_surfDiff=has_surfDiff)
+    if resolution == "0D":
+        assert result == eq.particle_0D_asmpt()
+    else:
+        assert result == eq.particle_1D_asmpt(has_surfDiff=has_surfDiff)
+
+
+# %% Equation term generators (bulk transport)
+
+@pytest.mark.ci
+@pytest.mark.parametrize("term_func, latex_fragment", [
+    (eq.bulk_time_derivative, r"\frac{\partial c^{\b}_i}{\partial t}"),
+    (eq.solid_time_derivative, r"\frac{\partial c^{\s}_i}{\partial t}"),
+    (eq.axial_convection, r"\partial z"),
+    (eq.axial_dispersion, r"D^{\mathrm{ax}}"),
+    (eq.radial_dispersion, r"D^{\mathrm{rad}}"),
+    (eq.angular_dispersion, r"D^{\mathrm{ang}}"),
+])
+def test_transport_term_without_eps(term_func, latex_fragment):
+    """Transport terms without porosity should contain their characteristic LaTeX fragment."""
+    assert latex_fragment in term_func()
+
+
+@pytest.mark.ci
+@pytest.mark.parametrize("term_func", [
+    eq.bulk_time_derivative,
+    eq.solid_time_derivative,
+    eq.axial_convection,
+    eq.axial_dispersion,
+    eq.radial_dispersion,
+    eq.angular_dispersion,
+])
+def test_transport_term_with_eps(term_func):
+    """When porosity is provided, all transport terms should include it."""
+    result = term_func(eps=r"\varepsilon")
+    assert r"\varepsilon" in result
+
+
+# %% Film diffusion term
+
+@pytest.mark.ci
+def test_int_filmDiff_single_particle():
+    """Single-particle film diffusion should not contain a summation."""
+    particle = _make_particle(surface_volume_ratio=3, resolution="1D")
+    result = eq.int_filmDiff_term(particle, 1, 1, singleParticle=True,
+                                   nonLimitingFilmDiff=False, hasSurfDiff=False)
+    assert r"k^{\mathrm{f}}" in result
+    assert r"\sum" not in result
+
+
+@pytest.mark.ci
+def test_int_filmDiff_multiple_particles():
+    """Multiple-particle film diffusion should contain a summation."""
+    particle = _make_particle(surface_volume_ratio=3, resolution="1D")
+    result = eq.int_filmDiff_term(particle, 1, 3, singleParticle=False,
+                                   nonLimitingFilmDiff=False, hasSurfDiff=False)
+    assert r"\sum" in result
+
+
+@pytest.mark.ci
+def test_int_filmDiff_nonlimiting_0D_returns_empty():
+    """Non-limiting film diffusion with 0D resolution should produce an empty string."""
+    particle = _make_particle(resolution="0D")
+    result = eq.int_filmDiff_term(particle, 1, 1, singleParticle=True,
+                                   nonLimitingFilmDiff=True, hasSurfDiff=False)
+    assert result == ""
+
+
+@pytest.mark.ci
+def test_int_filmDiff_nonlimiting_1D_substitutes_BC():
+    """Non-limiting film diffusion in 1D substitutes the BC into the term, removing k_f."""
+    particle = _make_particle(surface_volume_ratio=3, resolution="1D")
+    result = eq.int_filmDiff_term(particle, 1, 1, singleParticle=False,
+                                   nonLimitingFilmDiff=True, hasSurfDiff=False)
+    assert r"D^{\mathrm{p}}" in result
+    assert r"k^{\mathrm{f}}" not in result
+
+
+@pytest.mark.ci
+def test_int_filmDiff_nonlimiting_with_surfDiff():
+    """Non-limiting film diffusion with surface diffusion should include D^s."""
+    particle = _make_particle(surface_volume_ratio=3, resolution="1D")
+    result = eq.int_filmDiff_term(particle, 1, 1, singleParticle=False,
+                                   nonLimitingFilmDiff=True, hasSurfDiff=True)
+    assert r"D^{\mathrm{s}}" in result
+
+
+# %% Interstitial volume boundary conditions
+
+@pytest.mark.ci
+@pytest.mark.parametrize("resolution, hasAxDisp, expected, not_expected", [
+    ("1D", True,  [r"D^{\mathrm{ax}}", r"z=0", r"z=L"], []),
+    ("1D", False, [r"c_{\mathrm{in}"],                    [r"z=L"]),
+    ("2D", True,  [r"D^{\mathrm{rad}}", r"R^{\mathrm{c}}"], []),
+    ("3D", True,  [r"D^{\mathrm{ang}}", r"2\pi"],         []),
+])
+def test_int_vol_BC(resolution, hasAxDisp, expected, not_expected):
+    """Boundary conditions should include/exclude terms based on resolution and dispersion."""
+    result = eq.int_vol_BC(resolution, hasAxialDispersion=hasAxDisp)
+    for frag in expected:
+        assert frag in result
+    for frag in not_expected:
+        assert frag not in result
+
+
+# %% Interstitial volume initial conditions
+
+@pytest.mark.ci
+@pytest.mark.parametrize("resolution, includeParLiquid, has_bulk, has_par", [
+    ("1D", False, True,  False),
+    ("1D", True,  True,  True),
+    ("2D", False, True,  False),
+    ("3D", True,  True,  True),
+])
+def test_int_vol_initial(resolution, includeParLiquid, has_bulk, has_par):
+    """Initial conditions should include bulk and optionally particle liquid concentrations."""
+    result = eq.int_vol_initial(resolution, includeParLiquid=includeParLiquid)
+    assert (r"c^{\b}" in result) == has_bulk
+    assert (r"c^{\p}" in result) == has_par
+
+
+@pytest.mark.ci
+def test_int_vol_initial_2D_domain():
+    """2D initial conditions domain should reference column radius."""
+    result = eq.int_vol_initial("2D", includeParLiquid=False)
+    assert r"R^{\mathrm{c}}" in result
+
+
+@pytest.mark.ci
+def test_int_vol_initial_3D_domain():
+    """3D initial conditions domain should include angular component."""
+    result = eq.int_vol_initial("3D", includeParLiquid=False)
+    assert r"2\pi" in result
+
+
+# %% Domain functions
+
+@pytest.mark.ci
+@pytest.mark.parametrize("resolution, with_time, expected, not_expected", [
+    ("0D", True,  [r"T^\mathrm{end}"],              [r"L"]),
+    ("1D", True,  [r"T^\mathrm{end}", r"(0, L)"],   []),
+    ("2D", True,  [r"R^\mathrm{c}"],                []),
+    ("3D", True,  [r"2\pi"],                         []),
+    ("1D", False, [r"(0, L)"],                       [r"T^\mathrm{end}"]),
+])
+def test_int_vol_domain(resolution, with_time, expected, not_expected):
+    """Interstitial volume domain should grow with resolution dimension."""
+    result = eq.int_vol_domain(resolution, with_time_domain=with_time)
+    for frag in expected:
+        assert frag in result
+    for frag in not_expected:
+        assert frag not in result
+
+
+@pytest.mark.ci
+@pytest.mark.parametrize("hasCore, with_par_index, expected, not_expected", [
+    (False, False, [r"(0, R^{\mathrm{p}})"],  [r"R^{\mathrm{pc}}", r"_{j}"]),
+    (True,  False, [r"R^{\mathrm{pc}}"],       []),
+    (False, True,  [r"_{j}"],                  []),
+])
+def test_particle_domain(hasCore, with_par_index, expected, not_expected):
+    """Particle domain should reflect core presence and particle index."""
+    result = eq.particle_domain("1D", hasCore=hasCore, with_par_index=with_par_index)
+    for frag in expected:
+        assert frag in result
+    for frag in not_expected:
+        assert frag not in result
+
+
+@pytest.mark.ci
+@pytest.mark.parametrize("col_res, par_res, hasCore, with_time, expected, not_expected", [
+    ("1D", "1D", False, True,  [r"(0, L)", r"R^{\mathrm{p}}"],        []),
+    ("0D", "0D", False, True,  [r"T^\mathrm{end}"],                   [r"R^{\mathrm{p}}"]),
+    ("2D", "1D", False, True,  [r"R^\mathrm{c}"],                     []),
+    ("1D", "1D", True,  True,  [r"R^{\mathrm{pc}}"],                  []),
+    ("1D", "1D", False, False, [],                                     [r"T^\mathrm{end}"]),
+])
+def test_full_particle_conc_domain(col_res, par_res, hasCore, with_time, expected, not_expected):
+    """Full particle concentration domain should compose column and particle domains correctly."""
+    result = eq.full_particle_conc_domain(col_res, par_res, hasCore=hasCore, with_time_domain=with_time)
+    for frag in expected:
+        assert frag in result
+    for frag in not_expected:
+        assert frag not in result
+
+
+# %% Particle transport
+
+@pytest.mark.ci
+@pytest.mark.parametrize("resolution, geometry, has_binding, expected_frag", [
+    ("0D", "Sphere", True,  r"\begin{align}"),
+    ("0D", "Sphere", False, r"\begin{align}"),
+    ("1D", "Sphere", True,  r"r^2"),
+])
+def test_particle_transport_resolution_and_geometry(resolution, geometry, has_binding, expected_frag):
+    """Particle transport should select the correct equation form for given resolution and geometry."""
+    particle = _make_particle(resolution=resolution, geometry=geometry)
+    result = eq.particle_transport(
+        particle, singleParticle=True, nonlimiting_filmDiff=False,
+        has_surfDiff=False, has_binding=has_binding, req_binding=False,
+        has_mult_bnd_states=False)
+    assert expected_frag in result
+
+
+@pytest.mark.ci
+def test_particle_transport_single_removes_j_index():
+    """Single-particle transport equations should not contain the particle-type index j."""
+    particle = _make_particle(resolution="1D", geometry="Sphere")
+    result = eq.particle_transport(
+        particle, singleParticle=True, nonlimiting_filmDiff=False,
+        has_surfDiff=False, has_binding=True, req_binding=False,
+        has_mult_bnd_states=False)
+    assert "j,i" not in result
+
+
+@pytest.mark.ci
+def test_particle_transport_multiple_keeps_j_index():
+    """Multi-particle-type transport equations should contain the particle-type index j."""
+    particle = _make_particle(resolution="1D", geometry="Sphere")
+    result = eq.particle_transport(
+        particle, singleParticle=False, nonlimiting_filmDiff=False,
+        has_surfDiff=False, has_binding=True, req_binding=False,
+        has_mult_bnd_states=False)
+    assert "j,i" in result or "j}" in result
+
+
+# %% Particle transport radial (geometry-specific)
+
+@pytest.mark.ci
+@pytest.mark.parametrize("geometry, expected_frag", [
+    ("Sphere",   r"r^2"),
+    ("Cylinder", r"\frac{1}{r}"),
+    ("Slab",     r"\frac{\partial }{\partial r}"),
+])
+def test_particle_transport_radial_geometry(geometry, expected_frag):
+    """Radial transport should use the correct differential operator for each geometry."""
+    result = eq.particle_transport_radial(
+        geometry, has_surfDiff=False, has_binding=True,
+        req_binding=False, has_mult_bnd_states=False)
+    assert expected_frag in result
+
+
+@pytest.mark.ci
+def test_particle_transport_radial_surfDiff_toggle():
+    """Surface diffusion coefficient should appear only when has_surfDiff is True."""
+    with_sd = eq.particle_transport_radial(
+        "Sphere", has_surfDiff=True, has_binding=True,
+        req_binding=False, has_mult_bnd_states=False)
+    without_sd = eq.particle_transport_radial(
+        "Sphere", has_surfDiff=False, has_binding=True,
+        req_binding=False, has_mult_bnd_states=False)
+    assert r"D_{j,i}^{\s}" in with_sd
+    assert r"D_{j,i}^{\s}" not in without_sd
+
+
+@pytest.mark.ci
+def test_particle_transport_radial_req_binding():
+    """Rapid-equilibrium binding should set the solid phase LHS to zero."""
+    result = eq.particle_transport_radial(
+        "Sphere", has_surfDiff=False, has_binding=True,
+        req_binding=True, has_mult_bnd_states=False)
+    # The solid equation starts with "0 &="
+    assert r"0 " in result
+
+
+@pytest.mark.ci
+def test_particle_transport_radial_no_binding():
+    """Without binding, the solid phase concentration should not appear."""
+    result = eq.particle_transport_radial(
+        "Sphere", has_surfDiff=False, has_binding=False,
+        req_binding=False, has_mult_bnd_states=False)
+    assert r"c^{\s}" not in result
+
+
+@pytest.mark.ci
+def test_particle_transport_radial_mult_bnd_states():
+    """Multiple bound states should introduce a sum over bound state index k."""
+    result = eq.particle_transport_radial(
+        "Sphere", has_surfDiff=False, has_binding=True,
+        req_binding=False, has_mult_bnd_states=True)
+    assert r"N^{\mathrm{b}}" in result
+
+
+# %% Particle transport homogeneous
+
+@pytest.mark.ci
+def test_particle_transport_homogeneous_liquid_binding_toggle():
+    """Homogeneous liquid transport should include binding term only when binding is active."""
+    with_bnd = eq.particle_transport_homogeneous_liquid(
+        has_binding=True, req_binding=False, has_mult_bnd_states=False)
+    without_bnd = eq.particle_transport_homogeneous_liquid(
+        has_binding=False, req_binding=False, has_mult_bnd_states=False)
+    assert r"f^{\mathrm{bind}}" in with_bnd
+    assert r"f^{\mathrm{bind}}" not in without_bnd
+
+
+@pytest.mark.ci
+def test_particle_transport_homogeneous_solid_req_binding():
+    """Rapid-equilibrium solid transport should have zero on the LHS."""
+    result = eq.particle_transport_homogeneous_solid(
+        req_binding=True, has_mult_bnd_states=False)
+    assert "0" in result
+
+
+@pytest.mark.ci
+def test_particle_transport_homogeneous_combined():
+    """Combined homogeneous transport should wrap both equations in align environment."""
+    result = eq.particle_transport_homogeneous(
+        has_binding=True, req_binding=False, has_mult_bnd_states=False)
+    assert r"\begin{align}" in result
+    assert r"\end{align}" in result
+
+
+# %% Particle boundary conditions
+
+@pytest.mark.ci
+def test_particle_boundary_0D_returns_empty():
+    """0D particles have no spatial boundary, so boundary conditions should be empty."""
+    particle = _make_particle(resolution="0D")
+    result = eq.particle_boundary(
+        particle, singleParticle=True, nonlimiting_filmDiff=False,
+        has_surfDiff=False, has_binding=True, req_binding=False,
+        has_mult_bnd_states=False)
+    assert result == ""
+
+
+@pytest.mark.ci
+@pytest.mark.parametrize("has_core, expected_frag", [
+    (True,  r"R^{\mathrm{pc}}"),
+    (False, r"|_{r=0}"),
+])
+def test_particle_boundary_core_toggle(has_core, expected_frag):
+    """Inner boundary location should depend on particle core presence."""
+    particle = _make_particle(resolution="1D", has_core=has_core)
+    result = eq.particle_boundary(
+        particle, singleParticle=True, nonlimiting_filmDiff=False,
+        has_surfDiff=False, has_binding=True, req_binding=False,
+        has_mult_bnd_states=False)
+    assert expected_frag in result
+
+
+@pytest.mark.ci
+def test_particle_boundary_nonlimiting():
+    """Non-limiting film diffusion should set particle concentration equal to bulk at boundary."""
+    particle = _make_particle(resolution="1D", has_core=False)
+    result = eq.particle_boundary(
+        particle, singleParticle=True, nonlimiting_filmDiff=True,
+        has_surfDiff=False, has_binding=True, req_binding=False,
+        has_mult_bnd_states=False)
+    assert r"c^{\b}_i" in result
+
+
+@pytest.mark.ci
+def test_particle_boundary_single_particle_removes_j():
+    """Single-particle boundary conditions should not contain the particle type index."""
+    particle = _make_particle(resolution="1D", has_core=False)
+    result = eq.particle_boundary(
+        particle, singleParticle=True, nonlimiting_filmDiff=False,
+        has_surfDiff=False, has_binding=True, req_binding=False,
+        has_mult_bnd_states=False)
+    assert "j," not in result
+
+
+# %% Particle initial conditions
+
+@pytest.mark.ci
+@pytest.mark.parametrize("includeParLiquid, has_p, has_s", [
+    (True,  True,  True),
+    (False, False, True),
+])
+def test_particle_initial_liquid_toggle(includeParLiquid, has_p, has_s):
+    """Particle initial conditions should include liquid phase only when requested."""
+    domain = r"$(0, R^{\mathrm{p}})$"
+    result = eq.particle_initial(domain, singleParticle=True, includeParLiquid=includeParLiquid)
+    assert (r"c^{\p}" in result) == has_p
+    assert (r"c^{\s}" in result) == has_s
+
+
+@pytest.mark.ci
+def test_particle_initial_single_particle_removes_comma_j():
+    """Single-particle initial conditions should not contain ',j' subscript patterns."""
+    domain = r"$(0, R^{\mathrm{p}})$"
+    result = eq.particle_initial(domain, singleParticle=True, includeParLiquid=True)
+    assert ",j" not in result
+
+
+@pytest.mark.ci
+def test_particle_initial_multiple_particles_keeps_j():
+    """Multi-particle-type initial conditions should retain the particle-type index j."""
+    domain = r"$(0, R^{\mathrm{p}}_{j})$"
+    result = eq.particle_initial(domain, singleParticle=False, includeParLiquid=True)
+    assert "j," in result

--- a/test/test_equations.py
+++ b/test/test_equations.py
@@ -39,6 +39,7 @@ def _make_particle(**overrides):
 # %% HRM_asmpt
 
 @pytest.mark.ci
+@pytest.mark.unit_test
 @pytest.mark.parametrize("column_resolution, N_p, has_binding, expected_keyword", [
     ("0D (Homogeneous Tank)", 0, False, "tank"),
     ("1D (axial coordinate)", 0, False, "column"),
@@ -55,6 +56,7 @@ def test_HRM_asmpt_device_and_particle_text(column_resolution, N_p, has_binding,
 
 
 @pytest.mark.ci
+@pytest.mark.unit_test
 def test_HRM_asmpt_binding_toggle():
     """Binding-related assumptions should only appear when has_binding is True."""
     with_bnd = eq.HRM_asmpt(N_p=1, nonlimiting_filmDiff=False,
@@ -68,6 +70,7 @@ def test_HRM_asmpt_binding_toggle():
 
 
 @pytest.mark.ci
+@pytest.mark.unit_test
 def test_HRM_asmpt_filters_empty_strings():
     """Empty assumption strings resulting from disabled options should be removed."""
     result = eq.HRM_asmpt(N_p=0, nonlimiting_filmDiff=False,
@@ -79,6 +82,7 @@ def test_HRM_asmpt_filters_empty_strings():
 # %% Interstitial volume continuum assumptions
 
 @pytest.mark.ci
+@pytest.mark.unit_test
 @pytest.mark.parametrize("resolution, expected_keyword", [
     ("3D", "continuum"),
     ("2D", "radially symmetric"),
@@ -93,6 +97,7 @@ def test_int_vol_continuum_asmpt_per_resolution(resolution, expected_keyword):
 
 
 @pytest.mark.ci
+@pytest.mark.unit_test
 @pytest.mark.parametrize("N_p, expected_keyword", [
     (0, "tank"),
     (1, "interstitial volume"),
@@ -105,6 +110,7 @@ def test_int_vol_0D_volume_naming(N_p, expected_keyword):
 
 
 @pytest.mark.ci
+@pytest.mark.unit_test
 def test_int_vol_3D_multiple_particle_types():
     """Multiple particle types (N_p > 1) should mention representative radii."""
     result = eq.int_vol_3DContinuum_asmpt(N_p=2, nonlimiting_filmDiff=False)
@@ -115,6 +121,7 @@ def test_int_vol_3D_multiple_particle_types():
 # %% Particle assumptions
 
 @pytest.mark.ci
+@pytest.mark.unit_test
 def test_particle_asmpts_base():
     """Base particle assumptions should reference the outer particle surface."""
     result = eq.particle_asmpts()
@@ -123,6 +130,7 @@ def test_particle_asmpts_base():
 
 
 @pytest.mark.ci
+@pytest.mark.unit_test
 @pytest.mark.parametrize("has_surfDiff, expected_keyword", [
     (True, "surface diffusion"),
     (False, "no surface diffusion"),
@@ -135,6 +143,7 @@ def test_particle_1D_surfDiff_toggle(has_surfDiff, expected_keyword):
 
 
 @pytest.mark.ci
+@pytest.mark.unit_test
 def test_particle_0D_infinite_diffusion():
     """0D particles should state that diffusion is infinitely fast."""
     result = eq.particle_0D_asmpt()
@@ -142,6 +151,7 @@ def test_particle_0D_infinite_diffusion():
 
 
 @pytest.mark.ci
+@pytest.mark.unit_test
 @pytest.mark.parametrize("resolution, has_surfDiff", [
     ("0D", False),
     ("1D", True),
@@ -159,6 +169,7 @@ def test_particle_asmpt_router(resolution, has_surfDiff):
 # %% Equation term generators (bulk transport)
 
 @pytest.mark.ci
+@pytest.mark.unit_test
 @pytest.mark.parametrize("term_func, latex_fragment", [
     (eq.bulk_time_derivative, r"\frac{\partial c^{\b}_i}{\partial t}"),
     (eq.solid_time_derivative, r"\frac{\partial c^{\s}_i}{\partial t}"),
@@ -173,6 +184,7 @@ def test_transport_term_without_eps(term_func, latex_fragment):
 
 
 @pytest.mark.ci
+@pytest.mark.unit_test
 @pytest.mark.parametrize("term_func", [
     eq.bulk_time_derivative,
     eq.solid_time_derivative,
@@ -190,6 +202,7 @@ def test_transport_term_with_eps(term_func):
 # %% Film diffusion term
 
 @pytest.mark.ci
+@pytest.mark.unit_test
 def test_int_filmDiff_single_particle():
     """Single-particle film diffusion should not contain a summation."""
     particle = _make_particle(surface_volume_ratio=3, resolution="1D")
@@ -200,6 +213,7 @@ def test_int_filmDiff_single_particle():
 
 
 @pytest.mark.ci
+@pytest.mark.unit_test
 def test_int_filmDiff_multiple_particles():
     """Multiple-particle film diffusion should contain a summation."""
     particle = _make_particle(surface_volume_ratio=3, resolution="1D")
@@ -209,6 +223,7 @@ def test_int_filmDiff_multiple_particles():
 
 
 @pytest.mark.ci
+@pytest.mark.unit_test
 def test_int_filmDiff_nonlimiting_0D_returns_empty():
     """Non-limiting film diffusion with 0D resolution should produce an empty string."""
     particle = _make_particle(resolution="0D")
@@ -218,6 +233,7 @@ def test_int_filmDiff_nonlimiting_0D_returns_empty():
 
 
 @pytest.mark.ci
+@pytest.mark.unit_test
 def test_int_filmDiff_nonlimiting_1D_substitutes_BC():
     """Non-limiting film diffusion in 1D substitutes the BC into the term, removing k_f."""
     particle = _make_particle(surface_volume_ratio=3, resolution="1D")
@@ -228,6 +244,7 @@ def test_int_filmDiff_nonlimiting_1D_substitutes_BC():
 
 
 @pytest.mark.ci
+@pytest.mark.unit_test
 def test_int_filmDiff_nonlimiting_with_surfDiff():
     """Non-limiting film diffusion with surface diffusion should include D^s."""
     particle = _make_particle(surface_volume_ratio=3, resolution="1D")
@@ -239,6 +256,7 @@ def test_int_filmDiff_nonlimiting_with_surfDiff():
 # %% Interstitial volume boundary conditions
 
 @pytest.mark.ci
+@pytest.mark.unit_test
 @pytest.mark.parametrize("resolution, hasAxDisp, expected, not_expected", [
     ("1D", True,  [r"D^{\mathrm{ax}}", r"z=0", r"z=L"], []),
     ("1D", False, [r"c_{\mathrm{in}"],                    [r"z=L"]),
@@ -257,6 +275,7 @@ def test_int_vol_BC(resolution, hasAxDisp, expected, not_expected):
 # %% Interstitial volume initial conditions
 
 @pytest.mark.ci
+@pytest.mark.unit_test
 @pytest.mark.parametrize("resolution, includeParLiquid, has_bulk, has_par", [
     ("1D", False, True,  False),
     ("1D", True,  True,  True),
@@ -271,6 +290,7 @@ def test_int_vol_initial(resolution, includeParLiquid, has_bulk, has_par):
 
 
 @pytest.mark.ci
+@pytest.mark.unit_test
 def test_int_vol_initial_2D_domain():
     """2D initial conditions domain should reference column radius."""
     result = eq.int_vol_initial("2D", includeParLiquid=False)
@@ -278,6 +298,7 @@ def test_int_vol_initial_2D_domain():
 
 
 @pytest.mark.ci
+@pytest.mark.unit_test
 def test_int_vol_initial_3D_domain():
     """3D initial conditions domain should include angular component."""
     result = eq.int_vol_initial("3D", includeParLiquid=False)
@@ -287,6 +308,7 @@ def test_int_vol_initial_3D_domain():
 # %% Domain functions
 
 @pytest.mark.ci
+@pytest.mark.unit_test
 @pytest.mark.parametrize("resolution, with_time, expected, not_expected", [
     ("0D", True,  [r"T^\mathrm{end}"],              [r"L"]),
     ("1D", True,  [r"T^\mathrm{end}", r"(0, L)"],   []),
@@ -304,6 +326,7 @@ def test_int_vol_domain(resolution, with_time, expected, not_expected):
 
 
 @pytest.mark.ci
+@pytest.mark.unit_test
 @pytest.mark.parametrize("hasCore, with_par_index, expected, not_expected", [
     (False, False, [r"(0, R^{\mathrm{p}})"],  [r"R^{\mathrm{pc}}", r"_{j}"]),
     (True,  False, [r"R^{\mathrm{pc}}"],       []),
@@ -319,6 +342,7 @@ def test_particle_domain(hasCore, with_par_index, expected, not_expected):
 
 
 @pytest.mark.ci
+@pytest.mark.unit_test
 @pytest.mark.parametrize("col_res, par_res, hasCore, with_time, expected, not_expected", [
     ("1D", "1D", False, True,  [r"(0, L)", r"R^{\mathrm{p}}"],        []),
     ("0D", "0D", False, True,  [r"T^\mathrm{end}"],                   [r"R^{\mathrm{p}}"]),
@@ -338,6 +362,7 @@ def test_full_particle_conc_domain(col_res, par_res, hasCore, with_time, expecte
 # %% Particle transport
 
 @pytest.mark.ci
+@pytest.mark.unit_test
 @pytest.mark.parametrize("resolution, geometry, has_binding, expected_frag", [
     ("0D", "Sphere", True,  r"\begin{align}"),
     ("0D", "Sphere", False, r"\begin{align}"),
@@ -354,6 +379,7 @@ def test_particle_transport_resolution_and_geometry(resolution, geometry, has_bi
 
 
 @pytest.mark.ci
+@pytest.mark.unit_test
 def test_particle_transport_single_removes_j_index():
     """Single-particle transport equations should not contain the particle-type index j."""
     particle = _make_particle(resolution="1D", geometry="Sphere")
@@ -365,6 +391,7 @@ def test_particle_transport_single_removes_j_index():
 
 
 @pytest.mark.ci
+@pytest.mark.unit_test
 def test_particle_transport_multiple_keeps_j_index():
     """Multi-particle-type transport equations should contain the particle-type index j."""
     particle = _make_particle(resolution="1D", geometry="Sphere")
@@ -378,6 +405,7 @@ def test_particle_transport_multiple_keeps_j_index():
 # %% Particle transport radial (geometry-specific)
 
 @pytest.mark.ci
+@pytest.mark.unit_test
 @pytest.mark.parametrize("geometry, expected_frag", [
     ("Sphere",   r"r^2"),
     ("Cylinder", r"\frac{1}{r}"),
@@ -392,6 +420,7 @@ def test_particle_transport_radial_geometry(geometry, expected_frag):
 
 
 @pytest.mark.ci
+@pytest.mark.unit_test
 def test_particle_transport_radial_surfDiff_toggle():
     """Surface diffusion coefficient should appear only when has_surfDiff is True."""
     with_sd = eq.particle_transport_radial(
@@ -405,6 +434,7 @@ def test_particle_transport_radial_surfDiff_toggle():
 
 
 @pytest.mark.ci
+@pytest.mark.unit_test
 def test_particle_transport_radial_req_binding():
     """Rapid-equilibrium binding should set the solid phase LHS to zero."""
     result = eq.particle_transport_radial(
@@ -415,6 +445,7 @@ def test_particle_transport_radial_req_binding():
 
 
 @pytest.mark.ci
+@pytest.mark.unit_test
 def test_particle_transport_radial_no_binding():
     """Without binding, the solid phase concentration should not appear."""
     result = eq.particle_transport_radial(
@@ -424,6 +455,7 @@ def test_particle_transport_radial_no_binding():
 
 
 @pytest.mark.ci
+@pytest.mark.unit_test
 def test_particle_transport_radial_mult_bnd_states():
     """Multiple bound states should introduce a sum over bound state index k."""
     result = eq.particle_transport_radial(
@@ -435,6 +467,7 @@ def test_particle_transport_radial_mult_bnd_states():
 # %% Particle transport homogeneous
 
 @pytest.mark.ci
+@pytest.mark.unit_test
 def test_particle_transport_homogeneous_liquid_binding_toggle():
     """Homogeneous liquid transport should include binding term only when binding is active."""
     with_bnd = eq.particle_transport_homogeneous_liquid(
@@ -446,6 +479,7 @@ def test_particle_transport_homogeneous_liquid_binding_toggle():
 
 
 @pytest.mark.ci
+@pytest.mark.unit_test
 def test_particle_transport_homogeneous_solid_req_binding():
     """Rapid-equilibrium solid transport should have zero on the LHS."""
     result = eq.particle_transport_homogeneous_solid(
@@ -454,6 +488,7 @@ def test_particle_transport_homogeneous_solid_req_binding():
 
 
 @pytest.mark.ci
+@pytest.mark.unit_test
 def test_particle_transport_homogeneous_combined():
     """Combined homogeneous transport should wrap both equations in align environment."""
     result = eq.particle_transport_homogeneous(
@@ -465,6 +500,7 @@ def test_particle_transport_homogeneous_combined():
 # %% Particle boundary conditions
 
 @pytest.mark.ci
+@pytest.mark.unit_test
 def test_particle_boundary_0D_returns_empty():
     """0D particles have no spatial boundary, so boundary conditions should be empty."""
     particle = _make_particle(resolution="0D")
@@ -476,6 +512,7 @@ def test_particle_boundary_0D_returns_empty():
 
 
 @pytest.mark.ci
+@pytest.mark.unit_test
 @pytest.mark.parametrize("has_core, expected_frag", [
     (True,  r"R^{\mathrm{pc}}"),
     (False, r"|_{r=0}"),
@@ -491,6 +528,7 @@ def test_particle_boundary_core_toggle(has_core, expected_frag):
 
 
 @pytest.mark.ci
+@pytest.mark.unit_test
 def test_particle_boundary_nonlimiting():
     """Non-limiting film diffusion should set particle concentration equal to bulk at boundary."""
     particle = _make_particle(resolution="1D", has_core=False)
@@ -502,6 +540,7 @@ def test_particle_boundary_nonlimiting():
 
 
 @pytest.mark.ci
+@pytest.mark.unit_test
 def test_particle_boundary_single_particle_removes_j():
     """Single-particle boundary conditions should not contain the particle type index."""
     particle = _make_particle(resolution="1D", has_core=False)
@@ -515,6 +554,7 @@ def test_particle_boundary_single_particle_removes_j():
 # %% Particle initial conditions
 
 @pytest.mark.ci
+@pytest.mark.unit_test
 @pytest.mark.parametrize("includeParLiquid, has_p, has_s", [
     (True,  True,  True),
     (False, False, True),
@@ -528,6 +568,7 @@ def test_particle_initial_liquid_toggle(includeParLiquid, has_p, has_s):
 
 
 @pytest.mark.ci
+@pytest.mark.unit_test
 def test_particle_initial_single_particle_removes_comma_j():
     """Single-particle initial conditions should not contain ',j' subscript patterns."""
     domain = r"$(0, R^{\mathrm{p}})$"
@@ -536,6 +577,7 @@ def test_particle_initial_single_particle_removes_comma_j():
 
 
 @pytest.mark.ci
+@pytest.mark.unit_test
 def test_particle_initial_multiple_particles_keeps_j():
     """Multi-particle-type initial conditions should retain the particle-type index j."""
     domain = r"$(0, R^{\mathrm{p}}_{j})$"

--- a/test/test_load_CADET_h5.py
+++ b/test/test_load_CADET_h5.py
@@ -1,0 +1,154 @@
+# -*- coding: utf-8 -*-
+"""
+Unit tests for src/load_CADET_h5.py.
+Each public function is tested in isolation using mock HDF5 groups.
+"""
+
+import pytest
+import numpy as np
+from unittest.mock import MagicMock
+from src.load_CADET_h5 import (
+    get_h5_value,
+    map_unit_type_to_column_model,
+    map_unit_to_particle_model,
+    CADET_column_unit_types,
+)
+
+
+# %% Helpers
+
+def _make_h5_group(mapping: dict):
+    """Create a mock HDF5 group that mimics h5py dataset access.
+
+    Keys present in *mapping* return mock datasets whose [()] call
+    yields the corresponding value.  Missing keys return None.
+    """
+    group = MagicMock()
+
+    def get_side_effect(k):
+        if k in mapping:
+            ds = MagicMock()
+            val = mapping[k]
+            type(ds).__getitem__ = lambda self, idx: val
+            return ds
+        return None
+
+    group.get = get_side_effect
+    return group
+
+
+# %% get_h5_value
+
+@pytest.mark.ci
+def test_get_h5_value_missing_key():
+    """A missing key should return None."""
+    group = MagicMock()
+    group.get.return_value = None
+    assert get_h5_value(group, 'MISSING_KEY') is None
+
+
+@pytest.mark.ci
+def test_get_h5_value_decodes_bytes():
+    """Byte-string values should be decoded to str."""
+    group = _make_h5_group({'UNIT_TYPE': b'GENERAL_RATE_MODEL'})
+    assert get_h5_value(group, 'UNIT_TYPE') == 'GENERAL_RATE_MODEL'
+
+
+@pytest.mark.ci
+def test_get_h5_value_scalar():
+    """Scalar numeric values should be returned as-is."""
+    group = _make_h5_group({'COL_POROSITY': 0.37})
+    assert get_h5_value(group, 'COL_POROSITY') == 0.37
+
+
+@pytest.mark.ci
+def test_get_h5_value_array_first_entry():
+    """With firstEntryIfList=True (default), only the first element should be returned."""
+    group = _make_h5_group({'COL_DISPERSION': np.array([5.75e-8, 1.0e-7])})
+    assert get_h5_value(group, 'COL_DISPERSION', firstEntryIfList=True) == 5.75e-8
+
+
+@pytest.mark.ci
+def test_get_h5_value_array_full():
+    """With firstEntryIfList=False, the full array should be returned."""
+    arr = np.array([5.75e-8, 1.0e-7])
+    group = _make_h5_group({'COL_DISPERSION': arr})
+    result = get_h5_value(group, 'COL_DISPERSION', firstEntryIfList=False)
+    assert hasattr(result, '__len__')
+    assert len(result) == 2
+
+
+@pytest.mark.ci
+def test_get_h5_value_empty_array():
+    """An empty array with firstEntryIfList=True should return the empty array (no crash)."""
+    group = _make_h5_group({'EMPTY': np.array([])})
+    result = get_h5_value(group, 'EMPTY', firstEntryIfList=True)
+    assert hasattr(result, '__len__')
+    assert len(result) == 0
+
+
+# %% map_unit_type_to_column_model
+
+@pytest.mark.ci
+@pytest.mark.parametrize("unit_type, expected", [
+    ('GENERAL_RATE_MODEL',                 "1D (axial coordinate)"),
+    ('GENERAL_RATE_MODEL_DG',              "1D (axial coordinate)"),
+    ('LUMPED_RATE_MODEL_WITHOUT_PORES',    "1D (axial coordinate)"),
+    ('LUMPED_RATE_MODEL_WITH_PORES',       "1D (axial coordinate)"),
+    ('LUMPED_RATE_MODEL_WITHOUT_PORES_DG', "1D (axial coordinate)"),
+    ('LUMPED_RATE_MODEL_WITH_PORES_DG',    "1D (axial coordinate)"),
+    ('GENERAL_RATE_MODEL_2D',              "2D (axial and radial coordinate)"),
+    ('CSTR',                               "0D (Homogeneous Tank)"),
+])
+def test_map_unit_type_to_column_model(unit_type, expected):
+    """Every supported CADET unit type should map to its correct column resolution."""
+    assert map_unit_type_to_column_model(unit_type) == expected
+
+
+@pytest.mark.ci
+def test_map_unit_type_to_column_model_invalid():
+    """An unsupported unit type should raise ValueError."""
+    with pytest.raises(ValueError, match="Invalid unit type"):
+        map_unit_type_to_column_model('INVALID_MODEL')
+
+
+# %% map_unit_to_particle_model
+
+@pytest.mark.ci
+@pytest.mark.parametrize("unit_type, h5_values, expected", [
+    ('GENERAL_RATE_MODEL',              {'COL_POROSITY': 0.37},                                 "1D (radial coordinate)"),
+    ('GENERAL_RATE_MODEL',              {'COL_POROSITY': 1.0},                                  None),
+    ('LUMPED_RATE_MODEL_WITH_PORES',    {'COL_POROSITY': 0.37},                                 "0D (homogeneous)"),
+    ('LUMPED_RATE_MODEL_WITHOUT_PORES', {'TOTAL_POROSITY': 1.0},                                None),
+    ('LUMPED_RATE_MODEL_WITHOUT_PORES', {'TOTAL_POROSITY': 0.5, 'CONST_SOLID_VOLUME': 0.0},     None),
+    ('CSTR',                            {'TOTAL_POROSITY': 0.5, 'CONST_SOLID_VOLUME': 0.1},     "0D (homogeneous)"),
+    ('CSTR',                            {'TOTAL_POROSITY': 1.0},                                None),
+])
+def test_map_unit_to_particle_model(unit_type, h5_values, expected):
+    """Particle model mapping should depend on unit type and porosity/solid-volume values."""
+    group = _make_h5_group(h5_values)
+    assert map_unit_to_particle_model(unit_type, group) == expected
+
+
+@pytest.mark.ci
+def test_map_unit_to_particle_model_invalid():
+    """An unsupported unit type should raise ValueError."""
+    group = _make_h5_group({})
+    with pytest.raises(ValueError, match="Invalid unit type"):
+        map_unit_to_particle_model('INVALID_MODEL', group)
+
+
+# %% CADET_column_unit_types constant
+
+@pytest.mark.ci
+def test_CADET_column_unit_types_completeness():
+    """The constant should contain all 8 supported CADET column unit types."""
+    expected = [
+        'GENERAL_RATE_MODEL', 'LUMPED_RATE_MODEL_WITHOUT_PORES',
+        'LUMPED_RATE_MODEL_WITH_PORES', 'GENERAL_RATE_MODEL_DG',
+        'LUMPED_RATE_MODEL_WITHOUT_PORES_DG', 'LUMPED_RATE_MODEL_WITH_PORES_DG',
+        'GENERAL_RATE_MODEL_2D', 'CSTR'
+    ]
+    assert len(CADET_column_unit_types) == 8
+    for t in expected:
+        assert t in CADET_column_unit_types

--- a/test/test_load_CADET_h5.py
+++ b/test/test_load_CADET_h5.py
@@ -40,6 +40,7 @@ def _make_h5_group(mapping: dict):
 # %% get_h5_value
 
 @pytest.mark.ci
+@pytest.mark.unit_test
 def test_get_h5_value_missing_key():
     """A missing key should return None."""
     group = MagicMock()
@@ -48,6 +49,7 @@ def test_get_h5_value_missing_key():
 
 
 @pytest.mark.ci
+@pytest.mark.unit_test
 def test_get_h5_value_decodes_bytes():
     """Byte-string values should be decoded to str."""
     group = _make_h5_group({'UNIT_TYPE': b'GENERAL_RATE_MODEL'})
@@ -55,6 +57,7 @@ def test_get_h5_value_decodes_bytes():
 
 
 @pytest.mark.ci
+@pytest.mark.unit_test
 def test_get_h5_value_scalar():
     """Scalar numeric values should be returned as-is."""
     group = _make_h5_group({'COL_POROSITY': 0.37})
@@ -62,6 +65,7 @@ def test_get_h5_value_scalar():
 
 
 @pytest.mark.ci
+@pytest.mark.unit_test
 def test_get_h5_value_array_first_entry():
     """With firstEntryIfList=True (default), only the first element should be returned."""
     group = _make_h5_group({'COL_DISPERSION': np.array([5.75e-8, 1.0e-7])})
@@ -69,6 +73,7 @@ def test_get_h5_value_array_first_entry():
 
 
 @pytest.mark.ci
+@pytest.mark.unit_test
 def test_get_h5_value_array_full():
     """With firstEntryIfList=False, the full array should be returned."""
     arr = np.array([5.75e-8, 1.0e-7])
@@ -79,6 +84,7 @@ def test_get_h5_value_array_full():
 
 
 @pytest.mark.ci
+@pytest.mark.unit_test
 def test_get_h5_value_empty_array():
     """An empty array with firstEntryIfList=True should return the empty array (no crash)."""
     group = _make_h5_group({'EMPTY': np.array([])})
@@ -90,6 +96,7 @@ def test_get_h5_value_empty_array():
 # %% map_unit_type_to_column_model
 
 @pytest.mark.ci
+@pytest.mark.unit_test
 @pytest.mark.parametrize("unit_type, expected", [
     ('GENERAL_RATE_MODEL',                 "1D (axial coordinate)"),
     ('GENERAL_RATE_MODEL_DG',              "1D (axial coordinate)"),
@@ -106,6 +113,7 @@ def test_map_unit_type_to_column_model(unit_type, expected):
 
 
 @pytest.mark.ci
+@pytest.mark.unit_test
 def test_map_unit_type_to_column_model_invalid():
     """An unsupported unit type should raise ValueError."""
     with pytest.raises(ValueError, match="Invalid unit type"):
@@ -115,6 +123,7 @@ def test_map_unit_type_to_column_model_invalid():
 # %% map_unit_to_particle_model
 
 @pytest.mark.ci
+@pytest.mark.unit_test
 @pytest.mark.parametrize("unit_type, h5_values, expected", [
     ('GENERAL_RATE_MODEL',              {'COL_POROSITY': 0.37},                                 "1D (radial coordinate)"),
     ('GENERAL_RATE_MODEL',              {'COL_POROSITY': 1.0},                                  None),
@@ -131,6 +140,7 @@ def test_map_unit_to_particle_model(unit_type, h5_values, expected):
 
 
 @pytest.mark.ci
+@pytest.mark.unit_test
 def test_map_unit_to_particle_model_invalid():
     """An unsupported unit type should raise ValueError."""
     group = _make_h5_group({})
@@ -141,6 +151,7 @@ def test_map_unit_to_particle_model_invalid():
 # %% CADET_column_unit_types constant
 
 @pytest.mark.ci
+@pytest.mark.unit_test
 def test_CADET_column_unit_types_completeness():
     """The constant should contain all 8 supported CADET column unit types."""
     expected = [

--- a/test/test_rerender_variables.py
+++ b/test/test_rerender_variables.py
@@ -15,6 +15,7 @@ rerender_variables = _eg.rerender_variables
 # %% CADET format
 
 @pytest.mark.ci
+@pytest.mark.unit_test
 @pytest.mark.parametrize("input_str, expected_frag", [
     (r"c^{\b}",  r"\mathrm{b}"),
     (r"c^{\p}",  r"\mathrm{p}"),
@@ -28,6 +29,7 @@ def test_rerender_CADET_superscript_substitution(input_str, expected_frag):
 
 
 @pytest.mark.ci
+@pytest.mark.unit_test
 def test_rerender_CADET_preserves_longer_commands():
     """CADET format should not modify longer LaTeX commands like \\partial."""
     assert rerender_variables(r"\partial", "CADET") == r"\partial"
@@ -36,18 +38,21 @@ def test_rerender_CADET_preserves_longer_commands():
 # %% Legacy format
 
 @pytest.mark.ci
+@pytest.mark.unit_test
 def test_rerender_Legacy_bulk_conc():
     """Legacy format should strip the superscript from bulk concentration."""
     assert rerender_variables(r"c^{\b}", "Legacy") == "c"
 
 
 @pytest.mark.ci
+@pytest.mark.unit_test
 def test_rerender_Legacy_particle_conc():
     """Legacy format should move the particle phase to a subscript."""
     assert rerender_variables(r"c^{\p}_{i}", "Legacy") == r"c_{\mathrm{p},i}"
 
 
 @pytest.mark.ci
+@pytest.mark.unit_test
 def test_rerender_Legacy_solid_conc():
     """Legacy format should replace solid concentration c^s with q."""
     result = rerender_variables(r"c^{\s}", "Legacy")
@@ -57,6 +62,7 @@ def test_rerender_Legacy_solid_conc():
 # %% Error handling
 
 @pytest.mark.ci
+@pytest.mark.unit_test
 def test_rerender_invalid_format_raises():
     """An unsupported variable format should raise ValueError."""
     with pytest.raises(ValueError, match="not supported"):

--- a/test/test_rerender_variables.py
+++ b/test/test_rerender_variables.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+"""
+Unit tests for rerender_variables() from Equation-Generator.py.
+Covers CADET format, Legacy format, and error handling.
+"""
+
+import pytest
+from importlib import import_module
+
+# Equation-Generator.py has a hyphenated name, so we use importlib
+_eg = import_module("Equation-Generator")
+rerender_variables = _eg.rerender_variables
+
+
+# %% CADET format
+
+@pytest.mark.ci
+@pytest.mark.parametrize("input_str, expected_frag", [
+    (r"c^{\b}",  r"\mathrm{b}"),
+    (r"c^{\p}",  r"\mathrm{p}"),
+    (r"c^{\s}",  r"\mathrm{s}"),
+    (r"c^{\l}",  r"\mathrm{\ell}"),
+])
+def test_rerender_CADET_superscript_substitution(input_str, expected_frag):
+    """CADET format should wrap short LaTeX phase commands in \\mathrm."""
+    result = rerender_variables(input_str, "CADET")
+    assert expected_frag in result
+
+
+@pytest.mark.ci
+def test_rerender_CADET_preserves_longer_commands():
+    """CADET format should not modify longer LaTeX commands like \\partial."""
+    assert rerender_variables(r"\partial", "CADET") == r"\partial"
+
+
+# %% Legacy format
+
+@pytest.mark.ci
+def test_rerender_Legacy_bulk_conc():
+    """Legacy format should strip the superscript from bulk concentration."""
+    assert rerender_variables(r"c^{\b}", "Legacy") == "c"
+
+
+@pytest.mark.ci
+def test_rerender_Legacy_particle_conc():
+    """Legacy format should move the particle phase to a subscript."""
+    assert rerender_variables(r"c^{\p}_{i}", "Legacy") == r"c_{\mathrm{p},i}"
+
+
+@pytest.mark.ci
+def test_rerender_Legacy_solid_conc():
+    """Legacy format should replace solid concentration c^s with q."""
+    result = rerender_variables(r"c^{\s}", "Legacy")
+    assert "q" in result
+
+
+# %% Error handling
+
+@pytest.mark.ci
+def test_rerender_invalid_format_raises():
+    """An unsupported variable format should raise ValueError."""
+    with pytest.raises(ValueError, match="not supported"):
+        rerender_variables(r"c^{\b}", "InvalidFormat")


### PR DESCRIPTION
## Summary
- Add 117 unit tests for `equations.py`, `load_CADET_h5.py`, and `rerender_variables()`
- All tests marked with `@pytest.mark.ci` so they run in the existing CI pipeline
- Follows project conventions: top-level functions, `@pytest.parametrize`, docstrings

Closes #50