### PR TITLE
CI: add main script to coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
+    env:
+      COVERAGE_PROCESS_START: .coveragerc
+      PYTHONPATH: ${{ github.workspace }}
+
     defaults:
       run:
         shell: bash -l {0}
@@ -79,7 +83,6 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
         slug: cadet/CADET-Equations
         files: coverage.xml
-        flags: unit
         fail_ci_if_error: true
 
     - name: Run more integration tests without coverage

--- a/sitecustomize.py
+++ b/sitecustomize.py
@@ -1,0 +1,10 @@
+# sitecustomize.py — enables coverage in subprocesses when COVERAGE_PROCESS_START is set
+import os
+if os.getenv("COVERAGE_PROCESS_START"):
+    try:
+        # coverage.process_startup will read COVERAGE_PROCESS_START to configure coverage
+        import coverage
+        coverage.process_startup()
+    except Exception:
+        # avoid breaking test runs if coverage isn't available
+        pass


### PR DESCRIPTION
Export PYTHONPATH in the CI job env so that child Python processes (streamlit AppTest `AppTest.from_file`) can import sitecustomize.py from the repo root.