### PR TITLE
Add rapid-equilibrium reactions

### DIFF
--- a/Equation-Generator.py
+++ b/Equation-Generator.py
@@ -244,6 +244,28 @@ else:
 if show_eq_description:
     write_and_save("Here, " + column_model.vars_params_description())
 
+if column_model.has_reaction_bulk and column_model.req_reaction_bulk:
+    write_and_save(
+        r"The bulk liquid phase reactions are in rapid equilibrium. "
+        r"The resulting overdetermined system of $N^{\mathrm{c}}$ component transport equations is reduced through conserved moieties. "
+        r"Specifically, $N^{\mathrm{react,eq},\b}$ of the component equations are replaced by algebraic equilibrium constraints")
+    write_and_save(r"""
+\begin{align}
+""" + eq.req_reaction_bulk_constraint() + r""", \quad k = 1, \ldots, N^{\mathrm{react,eq},\b}.
+\end{align}
+""", as_latex=True)
+    write_and_save(
+        r"The remaining $N^{\mathrm{c}} - N^{\mathrm{react,eq},\b}$ equations are replaced by conserved moiety equations, "
+        r"obtained by left-multiplying the component transport equations with the conserved moiety matrix "
+        r"$M^{\b} \in \mathbb{R}^{(N^{\mathrm{c}} - N^{\mathrm{react,eq},\b}) \times N^{\mathrm{c}}}$, "
+        r"whose rows span the left null space of the stoichiometric matrix")
+    write_and_save(r"""
+\begin{align}
+""" + eq.conserved_moiety_equation_bulk() + r""", \quad l = 1, \ldots, N^{\mathrm{c}} - N^{\mathrm{react,eq},\b}.
+\end{align}
+""", as_latex=True)
+    write_and_save(r"By construction, the reaction terms cancel in the conserved moiety equations.")
+
 if column_model.N_p > 0:
 
     particle_eq, particle_bc = column_model.particle_equations()
@@ -277,8 +299,46 @@ if column_model.N_p > 0:
 
         if show_eq_description:
             write_and_save("Here, " + column_model.particle_models[0].vars_params_description())
-            
-            
+
+        # Rapid-equilibrium reactions in the particle phase
+        if column_model.has_reaction_particle_liquid and column_model.req_reaction_particle_liquid:
+            write_and_save(
+                r"The particle liquid phase reactions are in rapid equilibrium. "
+                r"The system is reduced through conserved moieties: "
+                r"$N^{\mathrm{react,eq},\p}$ algebraic equilibrium constraints")
+            write_and_save(r"""
+\begin{align}
+""" + eq.req_reaction_particle_liquid_constraint(column_model.N_p == 1) + r""", \quad k = 1, \ldots, N^{\mathrm{react,eq},\p}
+\end{align}
+""", as_latex=True)
+            write_and_save(
+                r"replace $N^{\mathrm{react,eq},\p}$ of the component equations. "
+                r"The remaining $N^{\mathrm{c}} - N^{\mathrm{react,eq},\p}$ equations are conserved moiety equations")
+            write_and_save(r"""
+\begin{align}
+""" + eq.conserved_moiety_equation_particle_liquid(column_model.N_p == 1) + r""", \quad l = 1, \ldots, N^{\mathrm{c}} - N^{\mathrm{react,eq},\p}.
+\end{align}
+""", as_latex=True)
+
+        if column_model.has_reaction_particle_solid and column_model.req_reaction_particle_solid:
+            write_and_save(
+                r"The particle solid phase reactions are in rapid equilibrium. "
+                r"The system is reduced through conserved moieties: "
+                r"$N^{\mathrm{react,eq},\s}$ algebraic equilibrium constraints")
+            write_and_save(r"""
+\begin{align}
+""" + eq.req_reaction_particle_solid_constraint(column_model.N_p == 1) + r""", \quad k = 1, \ldots, N^{\mathrm{react,eq},\s}
+\end{align}
+""", as_latex=True)
+            write_and_save(
+                r"replace $N^{\mathrm{react,eq},\s}$ of the component equations. "
+                r"The remaining $N^{\mathrm{c}} - N^{\mathrm{react,eq},\s}$ equations are conserved moiety equations")
+            write_and_save(r"""
+\begin{align}
+""" + eq.conserved_moiety_equation_particle_solid(column_model.N_p == 1) + r""", \quad l = 1, \ldots, N^{\mathrm{c}} - N^{\mathrm{react,eq},\s}.
+\end{align}
+""", as_latex=True)
+
         # Some more complicated binding models require additional equations
         if column_model.binding_model == "SMA" and column_model.has_binding: 
             

--- a/src/equations.py
+++ b/src/equations.py
@@ -308,6 +308,50 @@ def particle_solid_reaction_term(singleParticle: bool):
         return r"f^{\mathrm{react},\s}_{j,i}\left( \vec{c}^{\p}, \vec{c}^{\s} \right)"
 
 
+# Rapid-equilibrium reaction terms
+
+def req_reaction_bulk_constraint():
+    """Return the algebraic equilibrium constraint for bulk rapid-equilibrium reactions."""
+    return r"0 = g^{\mathrm{react,eq},\b}_{k}\left( \vec{c}^{\b} \right)"
+
+
+def req_reaction_particle_liquid_constraint(singleParticle: bool):
+    """Return the algebraic equilibrium constraint for particle liquid rapid-equilibrium reactions."""
+    if singleParticle:
+        return r"0 = g^{\mathrm{react,eq},\p}_{k}\left( \vec{c}^{\p}, \vec{c}^{\s} \right)"
+    else:
+        return r"0 = g^{\mathrm{react,eq},\p}_{j,k}\left( \vec{c}^{\p}, \vec{c}^{\s} \right)"
+
+
+def req_reaction_particle_solid_constraint(singleParticle: bool):
+    """Return the algebraic equilibrium constraint for particle solid rapid-equilibrium reactions."""
+    if singleParticle:
+        return r"0 = g^{\mathrm{react,eq},\s}_{k}\left( \vec{c}^{\p}, \vec{c}^{\s} \right)"
+    else:
+        return r"0 = g^{\mathrm{react,eq},\s}_{j,k}\left( \vec{c}^{\p}, \vec{c}^{\s} \right)"
+
+
+def conserved_moiety_equation_bulk():
+    """Return the conserved moiety transport equation for bulk rapid-equilibrium reactions."""
+    return r"""\sum_{i=0}^{N^{\mathrm{c}}-1} M^{\b}_{l,i} \left[ \text{transport equation of component } i \right] = 0"""
+
+
+def conserved_moiety_equation_particle_liquid(singleParticle: bool):
+    """Return the conserved moiety transport equation for particle liquid rapid-equilibrium reactions."""
+    if singleParticle:
+        return r"""\sum_{i=0}^{N^{\mathrm{c}}-1} M^{\p}_{l,i} \left[ \text{transport equation of component } i \right] = 0"""
+    else:
+        return r"""\sum_{i=0}^{N^{\mathrm{c}}-1} M^{\p}_{j,l,i} \left[ \text{transport equation of component } i \right] = 0"""
+
+
+def conserved_moiety_equation_particle_solid(singleParticle: bool):
+    """Return the conserved moiety transport equation for particle solid rapid-equilibrium reactions."""
+    if singleParticle:
+        return r"""\sum_{i=0}^{N^{\mathrm{c}}-1} M^{\s}_{l,i} \left[ \text{transport equation of component } i \right] = 0"""
+    else:
+        return r"""\sum_{i=0}^{N^{\mathrm{c}}-1} M^{\s}_{j,l,i} \left[ \text{transport equation of component } i \right] = 0"""
+
+
 # Boundary conditions of the interstitial volume equations
 
 

--- a/src/model_column.py
+++ b/src/model_column.py
@@ -61,6 +61,9 @@ class Column:
     has_reaction_bulk: bool = False
     has_reaction_particle_liquid: bool = False
     has_reaction_particle_solid: bool = False
+    req_reaction_bulk: bool = False
+    req_reaction_particle_liquid: bool = False
+    req_reaction_particle_solid: bool = False
 
     vars_and_params: List[dict] = field(default_factory=list)
 
@@ -186,7 +189,9 @@ class Column:
                         PTD=self.PTD,
                         binding_model=self.binding_model,
                         has_reaction_liquid=self.has_reaction_particle_liquid,
-                        has_reaction_solid=self.has_reaction_particle_solid
+                        has_reaction_solid=self.has_reaction_particle_solid,
+                        req_reaction_liquid=self.req_reaction_particle_liquid,
+                        req_reaction_solid=self.req_reaction_particle_solid
                     )
                 )
 
@@ -211,11 +216,20 @@ class Column:
             st.sidebar.write("Configure reactions")
             self.has_reaction_bulk = st.sidebar.selectbox(
                 "Add bulk liquid reaction", ["No", "Yes"], key=r"has_reaction_bulk") == "Yes"
+            if self.has_reaction_bulk:
+                self.req_reaction_bulk = st.sidebar.selectbox(
+                    "Bulk reaction kinetics mode", ["Kinetic", "Rapid-equilibrium"], key=r"req_reaction_bulk") == "Rapid-equilibrium"
             if self.N_p > 0:
                 self.has_reaction_particle_liquid = st.sidebar.selectbox(
                     "Add particle liquid reaction", ["No", "Yes"], key=r"has_reaction_particle_liquid") == "Yes"
+                if self.has_reaction_particle_liquid:
+                    self.req_reaction_particle_liquid = st.sidebar.selectbox(
+                        "Particle liquid reaction kinetics mode", ["Kinetic", "Rapid-equilibrium"], key=r"req_reaction_particle_liquid") == "Rapid-equilibrium"
                 self.has_reaction_particle_solid = st.sidebar.selectbox(
                     "Add particle solid reaction", ["No", "Yes"], key=r"has_reaction_particle_solid") == "Yes"
+                if self.has_reaction_particle_solid:
+                    self.req_reaction_particle_solid = st.sidebar.selectbox(
+                        "Particle solid reaction kinetics mode", ["Kinetic", "Rapid-equilibrium"], key=r"req_reaction_particle_solid") == "Rapid-equilibrium"
 
         self.fill_vars_and_params()
 
@@ -360,8 +374,14 @@ class Column:
                 symbol_name_ = r"k^\mathrm{f}_{i}" if self.N_p<=1 else r"k^\mathrm{f}_{j,i}"
                 self.vars_and_params.append({"Group" : 7, "Symbol": symbol_name_, "Description": r"film diffusion coefficient", "Unit": r"\frac{m}{s}", "Dependence": r"i" if self.N_p<=1 else r"j,i", "Property": r"\geq 0"})
 
-        if self.has_reaction_bulk:
+        if self.has_reaction_bulk and not self.req_reaction_bulk:
             self.vars_and_params.append({"Group" : 8, "Symbol": r"f^{\mathrm{react},\b}_{i}", "Description": r"bulk liquid phase reaction function", "Unit": r"\frac{mol}{m^3 \cdot s}", "Dependence": r"\vec{c}^{\b}; i"})
+            self.vars_and_params.append({"Group" : 8.1, "Symbol": r"\vec{c}^{\b}", "Description": r"bulk liquid components vector", "Unit": r"[\frac{mol}{m^3}]", "Dependence": state_deps})
+
+        if self.has_reaction_bulk and self.req_reaction_bulk:
+            self.vars_and_params.append({"Group" : 8, "Symbol": r"g^{\mathrm{react,eq},\b}_{k}", "Description": r"bulk liquid phase equilibrium constraint function", "Unit": r"\frac{mol}{m^3}", "Dependence": r"\vec{c}^{\b}; k"})
+            self.vars_and_params.append({"Group" : 8.1, "Symbol": r"N^{\mathrm{react,eq},\b}", "Description": r"number of rapid-equilibrium bulk reactions", "Unit": r"-", "Dependence": r"-"})
+            self.vars_and_params.append({"Group" : 8.1, "Symbol": r"M^{\b}", "Description": r"conserved moiety matrix for bulk reactions", "Unit": r"-", "Dependence": r"-"})
             self.vars_and_params.append({"Group" : 8.1, "Symbol": r"\vec{c}^{\b}", "Description": r"bulk liquid components vector", "Unit": r"[\frac{mol}{m^3}]", "Dependence": state_deps})
 
         for var_ in self.vars_and_params:
@@ -392,7 +412,7 @@ class Column:
             if self.nonlimiting_filmDiff and self.has_binding and self.particle_models[0].resolution == "0D" and not self.req_binding:
                 equation += r" - V^{\p} \left( 1 - \varepsilon^{\mathrm{p}} \right) \frac{\partial c^{\s}_i}{\partial t}"
 
-            if self.has_reaction_bulk:
+            if self.has_reaction_bulk and not self.req_reaction_bulk:
                 equation += " + " + eq.bulk_reaction_term()
 
         else:
@@ -437,7 +457,7 @@ class Column:
 
             par_added += self.par_unique_intV_contribution_counts[par_uniq]
 
-        if self.has_reaction_bulk and self.resolution != "0D":
+        if self.has_reaction_bulk and not self.req_reaction_bulk and self.resolution != "0D":
             equation += " + " + eq.bulk_reaction_term()
 
         if self.resolution == "0D":
@@ -465,7 +485,8 @@ class Column:
 
             eqs[par_type] = eq.particle_transport(par_type, singleParticle=self.N_p == 1, nonlimiting_filmDiff=self.nonlimiting_filmDiff,
                                                   has_surfDiff=self.has_surfDiff, has_binding=self.has_binding, req_binding=self.req_binding, has_mult_bnd_states=self.has_mult_bnd_states, PTD=self.PTD,
-                                                  has_reaction_liquid=self.has_reaction_particle_liquid, has_reaction_solid=self.has_reaction_particle_solid,
+                                                  has_reaction_liquid=self.has_reaction_particle_liquid and not self.req_reaction_particle_liquid,
+                                                  has_reaction_solid=self.has_reaction_particle_solid and not self.req_reaction_particle_solid,
                                                   binding_model=self.binding_model)
             eqs[par_type] = eqs[par_type]
 
@@ -557,6 +578,17 @@ class Column:
         if self.req_binding:
             asmpts["Specific model assumptions"].append(
                 r"adsorption and desorption happen on a much faster time scale than the other mass transfer processes (e.g., convection, diffusion). Hence, we consider them to be equilibrated instantly, that is, to always be in (local) equilibrium")
+
+        if self.req_reaction_bulk or self.req_reaction_particle_liquid or self.req_reaction_particle_solid:
+            phases = []
+            if self.req_reaction_bulk:
+                phases.append("bulk liquid")
+            if self.req_reaction_particle_liquid:
+                phases.append("particle liquid")
+            if self.req_reaction_particle_solid:
+                phases.append("particle solid")
+            asmpts["Specific model assumptions"].append(
+                r"reactions in the " + ", ".join(phases) + r" phase happen on a much faster time scale than the other mass transfer processes (e.g., convection, diffusion). Hence, the reaction equilibria are attained instantaneously and the system is reduced through conserved moieties")
 
         for idx in range(0, len(asmpts["Specific model assumptions"])):
             

--- a/src/model_column.py
+++ b/src/model_column.py
@@ -217,26 +217,26 @@ class Column:
         if not self.dev_mode:
             
             self.has_reaction_bulk = st.sidebar.selectbox(
-                "Add bulk liquid reaction (kinetic)", ["No", "Yes"], key=r"has_reaction_bulk") == "No"
+                "Add bulk liquid reaction (kinetic)", ["No", "Yes"], key=r"has_reaction_bulk") == "Yes"
         else:
             
             self.has_reaction_bulk = st.sidebar.selectbox(
-                "Add bulk liquid reaction", ["No", "Yes"], key=r"has_reaction_bulk") == "No"
+                "Add bulk liquid reaction", ["No", "Yes"], key=r"has_reaction_bulk") == "Yes"
         
         if self.has_reaction_bulk and self.dev_mode:
             
             self.req_reaction_bulk = st.sidebar.selectbox(
-                "Bulk reaction kinetics mode", ["Kinetic", "Rapid-equilibrium"], key=r"req_reaction_bulk") == "Kinetic"
+                "Bulk reaction kinetics mode", ["Kinetic", "Rapid-equilibrium"], key=r"req_reaction_bulk") == "Rapid-equilibrium"
         
         if self.N_p > 0 and self.dev_mode:
         
             self.has_reaction_particle_liquid = st.sidebar.selectbox(
-                "Add particle liquid reaction", ["No", "Yes"], key=r"has_reaction_particle_liquid") == "No"
+                "Add particle liquid reaction", ["No", "Yes"], key=r"has_reaction_particle_liquid") == "Yes"
             
             if self.has_reaction_particle_liquid:
             
                 self.req_reaction_particle_liquid = st.sidebar.selectbox(
-                    "Particle liquid reaction kinetics mode", ["Kinetic", "Rapid-equilibrium"], key=r"req_reaction_particle_liquid") == "Kinetic"
+                    "Particle liquid reaction kinetics mode", ["Kinetic", "Rapid-equilibrium"], key=r"req_reaction_particle_liquid") == "Rapid-equilibrium"
             
             if self.has_binding:
                 self.has_reaction_particle_solid = st.sidebar.selectbox(
@@ -244,7 +244,7 @@ class Column:
                 
                 if self.has_reaction_particle_solid:
                     self.req_reaction_particle_solid = st.sidebar.selectbox(
-                        "Particle solid reaction kinetics mode", ["Kinetic", "Rapid-equilibrium"], key=r"req_reaction_particle_solid") == "Kinetic"
+                        "Particle solid reaction kinetics mode", ["Kinetic", "Rapid-equilibrium"], key=r"req_reaction_particle_solid") == "Rapid-equilibrium"
 
         self.fill_vars_and_params()
 

--- a/src/model_column.py
+++ b/src/model_column.py
@@ -212,24 +212,39 @@ class Column:
         else:
             self.has_binding = False
 
-        if self.advanced_mode:
-            st.sidebar.write("Configure reactions")
+        st.sidebar.write("Configure reactions")
+        
+        if not self.dev_mode:
+            
             self.has_reaction_bulk = st.sidebar.selectbox(
-                "Add bulk liquid reaction", ["No", "Yes"], key=r"has_reaction_bulk") == "Yes"
-            if self.has_reaction_bulk:
-                self.req_reaction_bulk = st.sidebar.selectbox(
-                    "Bulk reaction kinetics mode", ["Kinetic", "Rapid-equilibrium"], key=r"req_reaction_bulk") == "Rapid-equilibrium"
-            if self.N_p > 0:
-                self.has_reaction_particle_liquid = st.sidebar.selectbox(
-                    "Add particle liquid reaction", ["No", "Yes"], key=r"has_reaction_particle_liquid") == "Yes"
-                if self.has_reaction_particle_liquid:
-                    self.req_reaction_particle_liquid = st.sidebar.selectbox(
-                        "Particle liquid reaction kinetics mode", ["Kinetic", "Rapid-equilibrium"], key=r"req_reaction_particle_liquid") == "Rapid-equilibrium"
+                "Add bulk liquid reaction (kinetic)", ["No", "Yes"], key=r"has_reaction_bulk") == "No"
+        else:
+            
+            self.has_reaction_bulk = st.sidebar.selectbox(
+                "Add bulk liquid reaction", ["No", "Yes"], key=r"has_reaction_bulk") == "No"
+        
+        if self.has_reaction_bulk and self.dev_mode:
+            
+            self.req_reaction_bulk = st.sidebar.selectbox(
+                "Bulk reaction kinetics mode", ["Kinetic", "Rapid-equilibrium"], key=r"req_reaction_bulk") == "Kinetic"
+        
+        if self.N_p > 0 and self.dev_mode:
+        
+            self.has_reaction_particle_liquid = st.sidebar.selectbox(
+                "Add particle liquid reaction", ["No", "Yes"], key=r"has_reaction_particle_liquid") == "No"
+            
+            if self.has_reaction_particle_liquid:
+            
+                self.req_reaction_particle_liquid = st.sidebar.selectbox(
+                    "Particle liquid reaction kinetics mode", ["Kinetic", "Rapid-equilibrium"], key=r"req_reaction_particle_liquid") == "Kinetic"
+            
+            if self.has_binding:
                 self.has_reaction_particle_solid = st.sidebar.selectbox(
                     "Add particle solid reaction", ["No", "Yes"], key=r"has_reaction_particle_solid") == "Yes"
+                
                 if self.has_reaction_particle_solid:
                     self.req_reaction_particle_solid = st.sidebar.selectbox(
-                        "Particle solid reaction kinetics mode", ["Kinetic", "Rapid-equilibrium"], key=r"req_reaction_particle_solid") == "Rapid-equilibrium"
+                        "Particle solid reaction kinetics mode", ["Kinetic", "Rapid-equilibrium"], key=r"req_reaction_particle_solid") == "Kinetic"
 
         self.fill_vars_and_params()
 

--- a/src/model_particle.py
+++ b/src/model_particle.py
@@ -38,6 +38,8 @@ class Particle:
     binding_model: str = "Arbitrary"
     has_reaction_liquid: bool = False
     has_reaction_solid: bool = False
+    req_reaction_liquid: bool = False
+    req_reaction_solid: bool = False
     # volume fraction ?
     # binding -> is_kinetic, nBound
     vars_and_params: List[dict] = field(default_factory=list, init=False, compare=False, hash=False)
@@ -124,15 +126,29 @@ class Particle:
             if self.has_core:
                 self.vars_and_params.append({"Group" : 0.1, "Symbol": r"R^\mathrm{pc}", "Description": r"particle core radius", "Unit": r"-", "Dependence": r"-", "Property": r"\in (0, R^\mathrm{p})"})
 
-        if self.has_reaction_liquid:
+        if self.has_reaction_liquid and not self.req_reaction_liquid:
             symbol_name_ = r"f^{\mathrm{react},\p}_{i}" if self.single_partype else r"f^{\mathrm{react},\p}_{j,i}"
             dep_ = r"\vec{c}^{\p}, \vec{c}^{\s}; i" if self.single_partype else r"\vec{c}^{\p}, \vec{c}^{\s}; j, i"
             vars_and_params_.append({"Group" : 10.2, "Symbol": symbol_name_, "Description": r"particle liquid phase reaction function", "Unit": r"\frac{mol}{m^3 \cdot s}", "Dependence": dep_})
 
-        if self.has_reaction_solid:
+        if self.has_reaction_liquid and self.req_reaction_liquid:
+            symbol_name_ = r"g^{\mathrm{react,eq},\p}_{k}" if self.single_partype else r"g^{\mathrm{react,eq},\p}_{j,k}"
+            dep_ = r"\vec{c}^{\p}, \vec{c}^{\s}; k" if self.single_partype else r"\vec{c}^{\p}, \vec{c}^{\s}; j, k"
+            vars_and_params_.append({"Group" : 10.2, "Symbol": symbol_name_, "Description": r"particle liquid phase equilibrium constraint function", "Unit": r"\frac{mol}{m^3}", "Dependence": dep_})
+            vars_and_params_.append({"Group" : 10.21, "Symbol": r"N^{\mathrm{react,eq},\p}", "Description": r"number of rapid-equilibrium particle liquid reactions", "Unit": r"-", "Dependence": r"-"})
+            vars_and_params_.append({"Group" : 10.21, "Symbol": r"M^{\p}", "Description": r"conserved moiety matrix for particle liquid reactions", "Unit": r"-", "Dependence": r"-"})
+
+        if self.has_reaction_solid and not self.req_reaction_solid:
             symbol_name_ = r"f^{\mathrm{react},\s}_{i}" if self.single_partype else r"f^{\mathrm{react},\s}_{j,i}"
             dep_ = r"\vec{c}^{\p}, \vec{c}^{\s}; i" if self.single_partype else r"\vec{c}^{\p}, \vec{c}^{\s}; j, i"
             vars_and_params_.append({"Group" : 10.3, "Symbol": symbol_name_, "Description": r"particle solid phase reaction function", "Unit": r"\frac{mol}{m^3 \cdot s}", "Dependence": dep_})
+
+        if self.has_reaction_solid and self.req_reaction_solid:
+            symbol_name_ = r"g^{\mathrm{react,eq},\s}_{k}" if self.single_partype else r"g^{\mathrm{react,eq},\s}_{j,k}"
+            dep_ = r"\vec{c}^{\p}, \vec{c}^{\s}; k" if self.single_partype else r"\vec{c}^{\p}, \vec{c}^{\s}; j, k"
+            vars_and_params_.append({"Group" : 10.3, "Symbol": symbol_name_, "Description": r"particle solid phase equilibrium constraint function", "Unit": r"\frac{mol}{m^3}", "Dependence": dep_})
+            vars_and_params_.append({"Group" : 10.31, "Symbol": r"N^{\mathrm{react,eq},\s}", "Description": r"number of rapid-equilibrium particle solid reactions", "Unit": r"-", "Dependence": r"-"})
+            vars_and_params_.append({"Group" : 10.31, "Symbol": r"M^{\s}", "Description": r"conserved moiety matrix for particle solid reactions", "Unit": r"-", "Dependence": r"-"})
 
         if not self.single_partype:
             vars_and_params_.append({"Group" : -0.1, "Symbol": r"j", "Description": r"particle type index", "Unit": r"-", "Dependence": r"-", "Property": r""})

--- a/test/test_model_particle.py
+++ b/test/test_model_particle.py
@@ -412,6 +412,7 @@ class TestParticleParallelParticleDistribution:
 class TestParticleReactions:
     """Test particle with reaction configurations."""
 
+    @pytest.mark.ci
     @pytest.mark.unit_test
     def test_particle_with_liquid_reaction(self):
         """Test particle with liquid phase reaction."""
@@ -427,6 +428,7 @@ class TestParticleReactions:
         )
         assert particle.has_reaction_liquid is True
 
+    @pytest.mark.ci
     @pytest.mark.unit_test
     def test_particle_with_solid_reaction(self):
         """Test particle with solid phase reaction."""
@@ -442,6 +444,7 @@ class TestParticleReactions:
         )
         assert particle.has_reaction_solid is True
 
+    @pytest.mark.ci
     @pytest.mark.unit_test
     def test_particle_with_both_reactions(self):
         """Test particle with both liquid and solid phase reactions."""
@@ -458,6 +461,110 @@ class TestParticleReactions:
         )
         assert particle.has_reaction_liquid is True
         assert particle.has_reaction_solid is True
+
+    @pytest.mark.ci
+    @pytest.mark.unit_test
+    def test_particle_with_req_reaction_liquid(self):
+        """Test particle with rapid-equilibrium liquid reaction."""
+        particle = Particle(
+            geometry="Sphere",
+            has_core=False,
+            var_format="CADET",
+            resolution="1D",
+            has_binding=True,
+            has_reaction_liquid=True,
+            req_reaction_liquid=True,
+            nonlimiting_filmDiff=False,
+            interstitial_volume_resolution="1D",
+        )
+        symbols = [v["Symbol"] for v in particle.vars_and_params]
+        assert any("g^{\\mathrm{react,eq}" in s for s in symbols)
+        assert any("M^{\\mathrm{p}}" in s for s in symbols)
+        assert not any("f^{\\mathrm{react},\\mathrm{p}}" in s for s in symbols)
+
+    @pytest.mark.ci
+    @pytest.mark.unit_test
+    def test_particle_with_req_reaction_solid(self):
+        """Test particle with rapid-equilibrium solid reaction."""
+        particle = Particle(
+            geometry="Sphere",
+            has_core=False,
+            var_format="CADET",
+            resolution="1D",
+            has_binding=True,
+            has_reaction_solid=True,
+            req_reaction_solid=True,
+            nonlimiting_filmDiff=False,
+            interstitial_volume_resolution="1D",
+        )
+        symbols = [v["Symbol"] for v in particle.vars_and_params]
+        assert any("g^{\\mathrm{react,eq}" in s for s in symbols)
+        assert any("M^{\\mathrm{s}}" in s for s in symbols)
+        assert not any("f^{\\mathrm{react},\\mathrm{s}}" in s for s in symbols)
+
+    @pytest.mark.ci
+    @pytest.mark.unit_test
+    def test_particle_with_req_reaction_both(self):
+        """Test particle with rapid-equilibrium reactions in both phases."""
+        particle = Particle(
+            geometry="Sphere",
+            has_core=False,
+            var_format="CADET",
+            resolution="1D",
+            has_binding=True,
+            has_reaction_liquid=True,
+            req_reaction_liquid=True,
+            has_reaction_solid=True,
+            req_reaction_solid=True,
+            nonlimiting_filmDiff=False,
+            interstitial_volume_resolution="1D",
+        )
+        symbols = [v["Symbol"] for v in particle.vars_and_params]
+        assert any("M^{\\mathrm{p}}" in s for s in symbols)
+        assert any("M^{\\mathrm{s}}" in s for s in symbols)
+
+    @pytest.mark.ci
+    @pytest.mark.unit_test
+    def test_particle_with_req_reaction_multi_partype(self):
+        """Test particle with rapid-equilibrium reactions and multiple particle types."""
+        particle = Particle(
+            geometry="Sphere",
+            has_core=False,
+            var_format="CADET",
+            resolution="1D",
+            has_binding=True,
+            has_reaction_liquid=True,
+            req_reaction_liquid=True,
+            has_reaction_solid=True,
+            req_reaction_solid=True,
+            single_partype=False,
+            nonlimiting_filmDiff=False,
+            interstitial_volume_resolution="1D",
+        )
+        symbols = [v["Symbol"] for v in particle.vars_and_params]
+        # Multi-partype should have j index in constraint symbols
+        assert any("j,k" in s for s in symbols)
+
+    @pytest.mark.ci
+    @pytest.mark.unit_test
+    def test_particle_kinetic_reaction_vars(self):
+        """Test that kinetic reaction keeps f^react symbols."""
+        particle = Particle(
+            geometry="Sphere",
+            has_core=False,
+            var_format="CADET",
+            resolution="1D",
+            has_binding=True,
+            has_reaction_liquid=True,
+            req_reaction_liquid=False,
+            has_reaction_solid=True,
+            req_reaction_solid=False,
+            nonlimiting_filmDiff=False,
+            interstitial_volume_resolution="1D",
+        )
+        symbols = [v["Symbol"] for v in particle.vars_and_params]
+        assert any("f^{\\mathrm{react},\\mathrm{p}}" in s for s in symbols)
+        assert any("f^{\\mathrm{react},\\mathrm{s}}" in s for s in symbols)
 
 
 class TestParticleVarsParamsDescription:

--- a/test/test_reactions.py
+++ b/test/test_reactions.py
@@ -363,12 +363,3 @@ def test_req_reaction_assumptions_multiple_phases():
     assert "conserved moieties" in latex
 
 
-@pytest.mark.ci
-@pytest.mark.unit_test
-def test_req_reaction_symbol_table():
-    """Test that symbol table contains rapid-equilibrium reaction symbols."""
-    at = setup_app_with_advanced_mode()
-    at.selectbox(key="has_reaction_bulk").set_value("Yes").run()
-    at.selectbox(key="req_reaction_bulk").set_value("Rapid-equilibrium").run()
-    at.toggle(key="sym_table").set_value(True).run()
-    assert not at.exception

--- a/test/test_reactions.py
+++ b/test/test_reactions.py
@@ -120,7 +120,45 @@ def test_bulk_reaction_0D_tank():
     assert r"f^{\mathrm{react}" in latex
 
 
-# === Rapid-equilibrium reaction tests ===
+# === Rapid-equilibrium reaction unit tests ===
+
+@pytest.mark.ci
+def test_req_reaction_equation_functions():
+    """Unit tests for rapid-equilibrium reaction equation snippet functions."""
+    from src import equations as eq
+
+    # Bulk constraint
+    result = eq.req_reaction_bulk_constraint()
+    assert r"g^{\mathrm{react,eq},\b}" in result
+
+    # Particle liquid constraint - single and multi particle
+    result_single = eq.req_reaction_particle_liquid_constraint(singleParticle=True)
+    assert r"g^{\mathrm{react,eq},\p}_{k}" in result_single
+    result_multi = eq.req_reaction_particle_liquid_constraint(singleParticle=False)
+    assert r"g^{\mathrm{react,eq},\p}_{j,k}" in result_multi
+
+    # Particle solid constraint - single and multi particle
+    result_single = eq.req_reaction_particle_solid_constraint(singleParticle=True)
+    assert r"g^{\mathrm{react,eq},\s}_{k}" in result_single
+    result_multi = eq.req_reaction_particle_solid_constraint(singleParticle=False)
+    assert r"g^{\mathrm{react,eq},\s}_{j,k}" in result_multi
+
+    # Conserved moiety equations
+    result = eq.conserved_moiety_equation_bulk()
+    assert r"M^{\b}" in result
+
+    result_single = eq.conserved_moiety_equation_particle_liquid(singleParticle=True)
+    assert r"M^{\p}_{l,i}" in result_single
+    result_multi = eq.conserved_moiety_equation_particle_liquid(singleParticle=False)
+    assert r"M^{\p}_{j,l,i}" in result_multi
+
+    result_single = eq.conserved_moiety_equation_particle_solid(singleParticle=True)
+    assert r"M^{\s}_{l,i}" in result_single
+    result_multi = eq.conserved_moiety_equation_particle_solid(singleParticle=False)
+    assert r"M^{\s}_{j,l,i}" in result_multi
+
+
+# === Rapid-equilibrium reaction integration tests ===
 
 @pytest.mark.ci
 def test_req_reaction_bulk():
@@ -244,3 +282,68 @@ def test_mixed_kinetic_and_req_reactions():
     assert r"f^{\mathrm{react}" in latex
     # Particle liquid should have equilibrium constraint
     assert r"g^{\mathrm{react,eq},\mathrm{p}}" in latex
+
+
+@pytest.mark.ci
+def test_req_reaction_bulk_0D_tank():
+    """Test rapid-equilibrium bulk reaction in 0D tank model."""
+    at = AppTest.from_file("../Equation-Generator.py")
+    at.run()
+    assert not at.exception
+    at.selectbox(key="advanced_mode").set_value("On").run()
+    at.selectbox(key="column_resolution").set_value("0D (Homogeneous Tank)").run()
+    at.selectbox(key="has_reaction_bulk").set_value("Yes").run()
+    at.selectbox(key="req_reaction_bulk").set_value("Rapid-equilibrium").run()
+    assert not at.exception
+    latex = at.session_state.latex_string
+    assert r"g^{\mathrm{react,eq},\mathrm{b}}" in latex
+    assert r"M^{\mathrm{b}}" in latex
+    assert r"f^{\mathrm{react},\mathrm{b}}" not in latex
+
+
+@pytest.mark.ci
+def test_req_reaction_with_psd():
+    """Test rapid-equilibrium reactions with particle size distribution (N_p > 1)."""
+    at = AppTest.from_file("../Equation-Generator.py")
+    at.run()
+    assert not at.exception
+    at.selectbox(key="advanced_mode").set_value("On").run()
+    at.selectbox(key="add_particles").set_value("Yes").run()
+    at.selectbox(key="PSD").set_value("Yes").run()
+    at.selectbox(key="has_binding").set_value("Yes").run()
+    at.selectbox(key="has_reaction_particle_liquid").set_value("Yes").run()
+    at.selectbox(key="req_reaction_particle_liquid").set_value("Rapid-equilibrium").run()
+    at.selectbox(key="has_reaction_particle_solid").set_value("Yes").run()
+    at.selectbox(key="req_reaction_particle_solid").set_value("Rapid-equilibrium").run()
+    assert not at.exception
+    latex = at.session_state.latex_string
+    assert r"g^{\mathrm{react,eq},\mathrm{p}}" in latex
+    assert r"g^{\mathrm{react,eq},\mathrm{s}}" in latex
+    assert r"M^{\mathrm{p}}" in latex
+    assert r"M^{\mathrm{s}}" in latex
+
+
+@pytest.mark.ci
+def test_req_reaction_assumptions_multiple_phases():
+    """Test assumptions text lists all phases with rapid-equilibrium reactions."""
+    at = setup_app_with_advanced_mode()
+    at.selectbox(key="has_reaction_bulk").set_value("Yes").run()
+    at.selectbox(key="req_reaction_bulk").set_value("Rapid-equilibrium").run()
+    at.selectbox(key="has_reaction_particle_liquid").set_value("Yes").run()
+    at.selectbox(key="req_reaction_particle_liquid").set_value("Rapid-equilibrium").run()
+    at.toggle(key="model_assumptions").set_value(True).run()
+    assert not at.exception
+    latex = at.session_state.latex_string
+    assert "bulk liquid" in latex
+    assert "particle liquid" in latex
+    assert "conserved moieties" in latex
+
+
+@pytest.mark.ci
+def test_req_reaction_symbol_table():
+    """Test that symbol table contains rapid-equilibrium reaction symbols."""
+    at = setup_app_with_advanced_mode()
+    at.selectbox(key="has_reaction_bulk").set_value("Yes").run()
+    at.selectbox(key="req_reaction_bulk").set_value("Rapid-equilibrium").run()
+    at.toggle(key="sym_table").set_value(True).run()
+    assert not at.exception

--- a/test/test_reactions.py
+++ b/test/test_reactions.py
@@ -355,11 +355,14 @@ def test_req_reaction_assumptions_multiple_phases():
     at.selectbox(key="req_reaction_bulk").set_value("Rapid-equilibrium").run()
     at.selectbox(key="has_reaction_particle_liquid").set_value("Yes").run()
     at.selectbox(key="req_reaction_particle_liquid").set_value("Rapid-equilibrium").run()
+    at.selectbox(key="has_reaction_particle_solid").set_value("Yes").run()
+    at.selectbox(key="req_reaction_particle_solid").set_value("Rapid-equilibrium").run()
     at.toggle(key="model_assumptions").set_value(True).run()
     assert not at.exception
     latex = at.session_state.latex_string
     assert "bulk liquid" in latex
     assert "particle liquid" in latex
+    assert "particle solid" in latex
     assert "conserved moieties" in latex
 
 

--- a/test/test_reactions.py
+++ b/test/test_reactions.py
@@ -118,3 +118,129 @@ def test_bulk_reaction_0D_tank():
     assert not at.exception
     latex = at.session_state.latex_string
     assert r"f^{\mathrm{react}" in latex
+
+
+# === Rapid-equilibrium reaction tests ===
+
+@pytest.mark.ci
+def test_req_reaction_bulk():
+    at = setup_app_with_advanced_mode()
+    at.selectbox(key="has_reaction_bulk").set_value("Yes").run()
+    at.selectbox(key="req_reaction_bulk").set_value("Rapid-equilibrium").run()
+    assert not at.exception
+    latex = at.session_state.latex_string
+    # Should have equilibrium constraint, not kinetic reaction term
+    assert r"g^{\mathrm{react,eq}" in latex
+    assert r"M^{\mathrm{b}}" in latex
+    assert r"f^{\mathrm{react},\mathrm{b}}" not in latex
+
+
+@pytest.mark.ci
+def test_req_reaction_bulk_no_particles():
+    at = setup_app_with_advanced_mode(add_particles="No")
+    at.selectbox(key="has_reaction_bulk").set_value("Yes").run()
+    at.selectbox(key="req_reaction_bulk").set_value("Rapid-equilibrium").run()
+    assert not at.exception
+    latex = at.session_state.latex_string
+    assert r"g^{\mathrm{react,eq},\mathrm{b}}" in latex
+    assert r"M^{\mathrm{b}}" in latex
+
+
+@pytest.mark.ci
+def test_req_reaction_particle_liquid_1D():
+    at = setup_app_with_advanced_mode(particle_resolution="1D (radial coordinate)")
+    at.selectbox(key="has_reaction_particle_liquid").set_value("Yes").run()
+    at.selectbox(key="req_reaction_particle_liquid").set_value("Rapid-equilibrium").run()
+    assert not at.exception
+    latex = at.session_state.latex_string
+    assert r"g^{\mathrm{react,eq},\mathrm{p}}" in latex
+    assert r"M^{\mathrm{p}}" in latex
+    assert r"f^{\mathrm{react},\mathrm{p}}" not in latex
+
+
+@pytest.mark.ci
+def test_req_reaction_particle_solid_1D():
+    at = setup_app_with_advanced_mode(particle_resolution="1D (radial coordinate)")
+    at.selectbox(key="has_reaction_particle_solid").set_value("Yes").run()
+    at.selectbox(key="req_reaction_particle_solid").set_value("Rapid-equilibrium").run()
+    assert not at.exception
+    latex = at.session_state.latex_string
+    assert r"g^{\mathrm{react,eq},\mathrm{s}}" in latex
+    assert r"M^{\mathrm{s}}" in latex
+    assert r"f^{\mathrm{react},\mathrm{s}}" not in latex
+
+
+@pytest.mark.ci
+def test_req_reaction_particle_liquid_0D():
+    at = setup_app_with_advanced_mode(particle_resolution="0D (homogeneous)")
+    at.selectbox(key="has_reaction_particle_liquid").set_value("Yes").run()
+    at.selectbox(key="req_reaction_particle_liquid").set_value("Rapid-equilibrium").run()
+    assert not at.exception
+    latex = at.session_state.latex_string
+    assert r"g^{\mathrm{react,eq},\mathrm{p}}" in latex
+    assert r"M^{\mathrm{p}}" in latex
+
+
+@pytest.mark.ci
+def test_req_reaction_particle_solid_0D():
+    at = setup_app_with_advanced_mode(particle_resolution="0D (homogeneous)")
+    at.selectbox(key="has_reaction_particle_solid").set_value("Yes").run()
+    at.selectbox(key="req_reaction_particle_solid").set_value("Rapid-equilibrium").run()
+    assert not at.exception
+    latex = at.session_state.latex_string
+    assert r"g^{\mathrm{react,eq},\mathrm{s}}" in latex
+    assert r"M^{\mathrm{s}}" in latex
+
+
+@pytest.mark.ci
+def test_req_reaction_all():
+    at = setup_app_with_advanced_mode()
+    at.selectbox(key="has_reaction_bulk").set_value("Yes").run()
+    at.selectbox(key="req_reaction_bulk").set_value("Rapid-equilibrium").run()
+    at.selectbox(key="has_reaction_particle_liquid").set_value("Yes").run()
+    at.selectbox(key="req_reaction_particle_liquid").set_value("Rapid-equilibrium").run()
+    at.selectbox(key="has_reaction_particle_solid").set_value("Yes").run()
+    at.selectbox(key="req_reaction_particle_solid").set_value("Rapid-equilibrium").run()
+    assert not at.exception
+    latex = at.session_state.latex_string
+    assert r"g^{\mathrm{react,eq},\mathrm{b}}" in latex
+    assert r"g^{\mathrm{react,eq},\mathrm{p}}" in latex
+    assert r"g^{\mathrm{react,eq},\mathrm{s}}" in latex
+    assert r"f^{\mathrm{react}" not in latex
+
+
+@pytest.mark.ci
+def test_req_reaction_kinetics_mode_not_shown_without_reaction():
+    at = setup_app_with_advanced_mode()
+    assert not at.exception
+    selectbox_keys = [box.key for box in at.selectbox]
+    assert "req_reaction_bulk" not in selectbox_keys
+    assert "req_reaction_particle_liquid" not in selectbox_keys
+    assert "req_reaction_particle_solid" not in selectbox_keys
+
+
+@pytest.mark.ci
+def test_req_reaction_assumptions():
+    at = setup_app_with_advanced_mode()
+    at.selectbox(key="has_reaction_bulk").set_value("Yes").run()
+    at.selectbox(key="req_reaction_bulk").set_value("Rapid-equilibrium").run()
+    at.toggle(key="model_assumptions").set_value(True).run()
+    assert not at.exception
+    latex = at.session_state.latex_string
+    assert "conserved moieties" in latex
+
+
+@pytest.mark.ci
+def test_mixed_kinetic_and_req_reactions():
+    """Test that kinetic and rapid-equilibrium reactions can coexist in different phases."""
+    at = setup_app_with_advanced_mode()
+    at.selectbox(key="has_reaction_bulk").set_value("Yes").run()
+    # bulk stays kinetic (default)
+    at.selectbox(key="has_reaction_particle_liquid").set_value("Yes").run()
+    at.selectbox(key="req_reaction_particle_liquid").set_value("Rapid-equilibrium").run()
+    assert not at.exception
+    latex = at.session_state.latex_string
+    # Bulk should have kinetic reaction term
+    assert r"f^{\mathrm{react}" in latex
+    # Particle liquid should have equilibrium constraint
+    assert r"g^{\mathrm{react,eq},\mathrm{p}}" in latex

--- a/test/test_reactions.py
+++ b/test/test_reactions.py
@@ -7,17 +7,20 @@ from streamlit.testing.v1 import AppTest
 import pytest
 
 
-def setup_app_with_advanced_mode(add_particles="Yes", particle_resolution="1D (radial coordinate)", has_binding="Yes"):
+def setup_app_with_dev_mode(add_particles="Yes", particle_resolution="1D (radial coordinate)", has_binding="Yes"):
     at = AppTest.from_file("../Equation-Generator.py")
     at.run()
     assert not at.exception
 
     at.selectbox(key="advanced_mode").set_value("On").run()
+    at.selectbox(key="dev_mode").set_value("On").run()
     assert not at.exception
 
     if add_particles == "Yes":
         at.selectbox(key="add_particles").set_value("Yes").run()
-        at.selectbox(key="particle_resolution").set_value(particle_resolution).run()
+        # dev_mode overrides N_p with a number_input (defaults to 0)
+        at.number_input(key=r"N^\mathrm{p}").set_value(1).run()
+        at.selectbox(key="parType_1_resolution").set_value(particle_resolution).run()
         at.selectbox(key="has_binding").set_value(has_binding).run()
 
     return at
@@ -26,7 +29,7 @@ def setup_app_with_advanced_mode(add_particles="Yes", particle_resolution="1D (r
 @pytest.mark.ci
 @pytest.mark.unit_test
 def test_bulk_reaction_no_particles():
-    at = setup_app_with_advanced_mode(add_particles="No")
+    at = setup_app_with_dev_mode(add_particles="No")
     at.selectbox(key="has_reaction_bulk").set_value("Yes").run()
     assert not at.exception
     latex = at.session_state.latex_string
@@ -36,7 +39,7 @@ def test_bulk_reaction_no_particles():
 @pytest.mark.ci
 @pytest.mark.unit_test
 def test_bulk_reaction_with_particles():
-    at = setup_app_with_advanced_mode()
+    at = setup_app_with_dev_mode()
     at.selectbox(key="has_reaction_bulk").set_value("Yes").run()
     assert not at.exception
     latex = at.session_state.latex_string
@@ -46,7 +49,7 @@ def test_bulk_reaction_with_particles():
 @pytest.mark.ci
 @pytest.mark.unit_test
 def test_particle_liquid_reaction_1D():
-    at = setup_app_with_advanced_mode(particle_resolution="1D (radial coordinate)")
+    at = setup_app_with_dev_mode(particle_resolution="1D (radial coordinate)")
     at.selectbox(key="has_reaction_particle_liquid").set_value("Yes").run()
     assert not at.exception
     latex = at.session_state.latex_string
@@ -56,7 +59,7 @@ def test_particle_liquid_reaction_1D():
 @pytest.mark.ci
 @pytest.mark.unit_test
 def test_particle_solid_reaction_1D():
-    at = setup_app_with_advanced_mode(particle_resolution="1D (radial coordinate)")
+    at = setup_app_with_dev_mode(particle_resolution="1D (radial coordinate)")
     at.selectbox(key="has_reaction_particle_solid").set_value("Yes").run()
     assert not at.exception
     latex = at.session_state.latex_string
@@ -66,7 +69,7 @@ def test_particle_solid_reaction_1D():
 @pytest.mark.ci
 @pytest.mark.unit_test
 def test_particle_liquid_reaction_0D():
-    at = setup_app_with_advanced_mode(particle_resolution="0D (homogeneous)")
+    at = setup_app_with_dev_mode(particle_resolution="0D (homogeneous)")
     at.selectbox(key="has_reaction_particle_liquid").set_value("Yes").run()
     assert not at.exception
     latex = at.session_state.latex_string
@@ -76,7 +79,7 @@ def test_particle_liquid_reaction_0D():
 @pytest.mark.ci
 @pytest.mark.unit_test
 def test_particle_solid_reaction_0D():
-    at = setup_app_with_advanced_mode(particle_resolution="0D (homogeneous)")
+    at = setup_app_with_dev_mode(particle_resolution="0D (homogeneous)")
     at.selectbox(key="has_reaction_particle_solid").set_value("Yes").run()
     assert not at.exception
     latex = at.session_state.latex_string
@@ -86,7 +89,7 @@ def test_particle_solid_reaction_0D():
 @pytest.mark.ci
 @pytest.mark.unit_test
 def test_all_reactions_enabled():
-    at = setup_app_with_advanced_mode()
+    at = setup_app_with_dev_mode()
     at.selectbox(key="has_reaction_bulk").set_value("Yes").run()
     at.selectbox(key="has_reaction_particle_liquid").set_value("Yes").run()
     at.selectbox(key="has_reaction_particle_solid").set_value("Yes").run()
@@ -100,7 +103,7 @@ def test_all_reactions_enabled():
 @pytest.mark.ci
 @pytest.mark.unit_test
 def test_no_reactions_by_default():
-    at = setup_app_with_advanced_mode()
+    at = setup_app_with_dev_mode()
     assert not at.exception
     latex = at.session_state.latex_string
     assert r"f^{\mathrm{react}" not in latex
@@ -108,12 +111,17 @@ def test_no_reactions_by_default():
 
 @pytest.mark.ci
 @pytest.mark.unit_test
-def test_reactions_only_in_advanced_mode():
+def test_req_reactions_only_in_dev_mode():
+    """Rapid-equilibrium and particle reaction selectboxes should not appear without dev_mode."""
     at = AppTest.from_file("../Equation-Generator.py")
     at.run()
     assert not at.exception
+    at.selectbox(key="advanced_mode").set_value("On").run()
+    at.selectbox(key="has_reaction_bulk").set_value("Yes").run()
+    assert not at.exception
     selectbox_keys = [box.key for box in at.selectbox]
-    assert "has_reaction_bulk" not in selectbox_keys
+    assert "req_reaction_bulk" not in selectbox_keys
+    assert "has_reaction_particle_liquid" not in selectbox_keys
 
 
 @pytest.mark.ci
@@ -123,6 +131,7 @@ def test_bulk_reaction_0D_tank():
     at.run()
     assert not at.exception
     at.selectbox(key="advanced_mode").set_value("On").run()
+    at.selectbox(key="dev_mode").set_value("On").run()
     at.selectbox(key="column_resolution").set_value("0D (Homogeneous Tank)").run()
     at.selectbox(key="has_reaction_bulk").set_value("Yes").run()
     assert not at.exception
@@ -174,7 +183,7 @@ def test_req_reaction_equation_functions():
 @pytest.mark.ci
 @pytest.mark.unit_test
 def test_req_reaction_bulk():
-    at = setup_app_with_advanced_mode()
+    at = setup_app_with_dev_mode()
     at.selectbox(key="has_reaction_bulk").set_value("Yes").run()
     at.selectbox(key="req_reaction_bulk").set_value("Rapid-equilibrium").run()
     assert not at.exception
@@ -188,7 +197,7 @@ def test_req_reaction_bulk():
 @pytest.mark.ci
 @pytest.mark.unit_test
 def test_req_reaction_bulk_no_particles():
-    at = setup_app_with_advanced_mode(add_particles="No")
+    at = setup_app_with_dev_mode(add_particles="No")
     at.selectbox(key="has_reaction_bulk").set_value("Yes").run()
     at.selectbox(key="req_reaction_bulk").set_value("Rapid-equilibrium").run()
     assert not at.exception
@@ -200,7 +209,7 @@ def test_req_reaction_bulk_no_particles():
 @pytest.mark.ci
 @pytest.mark.unit_test
 def test_req_reaction_particle_liquid_1D():
-    at = setup_app_with_advanced_mode(particle_resolution="1D (radial coordinate)")
+    at = setup_app_with_dev_mode(particle_resolution="1D (radial coordinate)")
     at.selectbox(key="has_reaction_particle_liquid").set_value("Yes").run()
     at.selectbox(key="req_reaction_particle_liquid").set_value("Rapid-equilibrium").run()
     assert not at.exception
@@ -213,7 +222,7 @@ def test_req_reaction_particle_liquid_1D():
 @pytest.mark.ci
 @pytest.mark.unit_test
 def test_req_reaction_particle_solid_1D():
-    at = setup_app_with_advanced_mode(particle_resolution="1D (radial coordinate)")
+    at = setup_app_with_dev_mode(particle_resolution="1D (radial coordinate)")
     at.selectbox(key="has_reaction_particle_solid").set_value("Yes").run()
     at.selectbox(key="req_reaction_particle_solid").set_value("Rapid-equilibrium").run()
     assert not at.exception
@@ -226,7 +235,7 @@ def test_req_reaction_particle_solid_1D():
 @pytest.mark.ci
 @pytest.mark.unit_test
 def test_req_reaction_particle_liquid_0D():
-    at = setup_app_with_advanced_mode(particle_resolution="0D (homogeneous)")
+    at = setup_app_with_dev_mode(particle_resolution="0D (homogeneous)")
     at.selectbox(key="has_reaction_particle_liquid").set_value("Yes").run()
     at.selectbox(key="req_reaction_particle_liquid").set_value("Rapid-equilibrium").run()
     assert not at.exception
@@ -238,7 +247,7 @@ def test_req_reaction_particle_liquid_0D():
 @pytest.mark.ci
 @pytest.mark.unit_test
 def test_req_reaction_particle_solid_0D():
-    at = setup_app_with_advanced_mode(particle_resolution="0D (homogeneous)")
+    at = setup_app_with_dev_mode(particle_resolution="0D (homogeneous)")
     at.selectbox(key="has_reaction_particle_solid").set_value("Yes").run()
     at.selectbox(key="req_reaction_particle_solid").set_value("Rapid-equilibrium").run()
     assert not at.exception
@@ -250,7 +259,7 @@ def test_req_reaction_particle_solid_0D():
 @pytest.mark.ci
 @pytest.mark.unit_test
 def test_req_reaction_all():
-    at = setup_app_with_advanced_mode()
+    at = setup_app_with_dev_mode()
     at.selectbox(key="has_reaction_bulk").set_value("Yes").run()
     at.selectbox(key="req_reaction_bulk").set_value("Rapid-equilibrium").run()
     at.selectbox(key="has_reaction_particle_liquid").set_value("Yes").run()
@@ -268,7 +277,7 @@ def test_req_reaction_all():
 @pytest.mark.ci
 @pytest.mark.unit_test
 def test_req_reaction_kinetics_mode_not_shown_without_reaction():
-    at = setup_app_with_advanced_mode()
+    at = setup_app_with_dev_mode()
     assert not at.exception
     selectbox_keys = [box.key for box in at.selectbox]
     assert "req_reaction_bulk" not in selectbox_keys
@@ -279,7 +288,7 @@ def test_req_reaction_kinetics_mode_not_shown_without_reaction():
 @pytest.mark.ci
 @pytest.mark.unit_test
 def test_req_reaction_assumptions():
-    at = setup_app_with_advanced_mode()
+    at = setup_app_with_dev_mode()
     at.selectbox(key="has_reaction_bulk").set_value("Yes").run()
     at.selectbox(key="req_reaction_bulk").set_value("Rapid-equilibrium").run()
     at.toggle(key="model_assumptions").set_value(True).run()
@@ -292,7 +301,7 @@ def test_req_reaction_assumptions():
 @pytest.mark.unit_test
 def test_mixed_kinetic_and_req_reactions():
     """Test that kinetic and rapid-equilibrium reactions can coexist in different phases."""
-    at = setup_app_with_advanced_mode()
+    at = setup_app_with_dev_mode()
     at.selectbox(key="has_reaction_bulk").set_value("Yes").run()
     # bulk stays kinetic (default)
     at.selectbox(key="has_reaction_particle_liquid").set_value("Yes").run()
@@ -313,6 +322,7 @@ def test_req_reaction_bulk_0D_tank():
     at.run()
     assert not at.exception
     at.selectbox(key="advanced_mode").set_value("On").run()
+    at.selectbox(key="dev_mode").set_value("On").run()
     at.selectbox(key="column_resolution").set_value("0D (Homogeneous Tank)").run()
     at.selectbox(key="has_reaction_bulk").set_value("Yes").run()
     at.selectbox(key="req_reaction_bulk").set_value("Rapid-equilibrium").run()
@@ -331,8 +341,10 @@ def test_req_reaction_with_psd():
     at.run()
     assert not at.exception
     at.selectbox(key="advanced_mode").set_value("On").run()
+    at.selectbox(key="dev_mode").set_value("On").run()
     at.selectbox(key="add_particles").set_value("Yes").run()
-    at.selectbox(key="PSD").set_value("Yes").run()
+    # dev_mode uses number_input for N_p instead of PSD selectbox
+    at.number_input(key=r"N^\mathrm{p}").set_value(2).run()
     at.selectbox(key="has_binding").set_value("Yes").run()
     at.selectbox(key="has_reaction_particle_liquid").set_value("Yes").run()
     at.selectbox(key="req_reaction_particle_liquid").set_value("Rapid-equilibrium").run()
@@ -350,7 +362,7 @@ def test_req_reaction_with_psd():
 @pytest.mark.unit_test
 def test_req_reaction_assumptions_multiple_phases():
     """Test assumptions text lists all phases with rapid-equilibrium reactions."""
-    at = setup_app_with_advanced_mode()
+    at = setup_app_with_dev_mode()
     at.selectbox(key="has_reaction_bulk").set_value("Yes").run()
     at.selectbox(key="req_reaction_bulk").set_value("Rapid-equilibrium").run()
     at.selectbox(key="has_reaction_particle_liquid").set_value("Yes").run()
@@ -364,5 +376,3 @@ def test_req_reaction_assumptions_multiple_phases():
     assert "particle liquid" in latex
     assert "particle solid" in latex
     assert "conserved moieties" in latex
-
-

--- a/test/test_reactions.py
+++ b/test/test_reactions.py
@@ -24,6 +24,7 @@ def setup_app_with_advanced_mode(add_particles="Yes", particle_resolution="1D (r
 
 
 @pytest.mark.ci
+@pytest.mark.unit_test
 def test_bulk_reaction_no_particles():
     at = setup_app_with_advanced_mode(add_particles="No")
     at.selectbox(key="has_reaction_bulk").set_value("Yes").run()
@@ -33,6 +34,7 @@ def test_bulk_reaction_no_particles():
 
 
 @pytest.mark.ci
+@pytest.mark.unit_test
 def test_bulk_reaction_with_particles():
     at = setup_app_with_advanced_mode()
     at.selectbox(key="has_reaction_bulk").set_value("Yes").run()
@@ -42,6 +44,7 @@ def test_bulk_reaction_with_particles():
 
 
 @pytest.mark.ci
+@pytest.mark.unit_test
 def test_particle_liquid_reaction_1D():
     at = setup_app_with_advanced_mode(particle_resolution="1D (radial coordinate)")
     at.selectbox(key="has_reaction_particle_liquid").set_value("Yes").run()
@@ -51,6 +54,7 @@ def test_particle_liquid_reaction_1D():
 
 
 @pytest.mark.ci
+@pytest.mark.unit_test
 def test_particle_solid_reaction_1D():
     at = setup_app_with_advanced_mode(particle_resolution="1D (radial coordinate)")
     at.selectbox(key="has_reaction_particle_solid").set_value("Yes").run()
@@ -60,6 +64,7 @@ def test_particle_solid_reaction_1D():
 
 
 @pytest.mark.ci
+@pytest.mark.unit_test
 def test_particle_liquid_reaction_0D():
     at = setup_app_with_advanced_mode(particle_resolution="0D (homogeneous)")
     at.selectbox(key="has_reaction_particle_liquid").set_value("Yes").run()
@@ -69,6 +74,7 @@ def test_particle_liquid_reaction_0D():
 
 
 @pytest.mark.ci
+@pytest.mark.unit_test
 def test_particle_solid_reaction_0D():
     at = setup_app_with_advanced_mode(particle_resolution="0D (homogeneous)")
     at.selectbox(key="has_reaction_particle_solid").set_value("Yes").run()
@@ -78,6 +84,7 @@ def test_particle_solid_reaction_0D():
 
 
 @pytest.mark.ci
+@pytest.mark.unit_test
 def test_all_reactions_enabled():
     at = setup_app_with_advanced_mode()
     at.selectbox(key="has_reaction_bulk").set_value("Yes").run()
@@ -91,6 +98,7 @@ def test_all_reactions_enabled():
 
 
 @pytest.mark.ci
+@pytest.mark.unit_test
 def test_no_reactions_by_default():
     at = setup_app_with_advanced_mode()
     assert not at.exception
@@ -99,6 +107,7 @@ def test_no_reactions_by_default():
 
 
 @pytest.mark.ci
+@pytest.mark.unit_test
 def test_reactions_only_in_advanced_mode():
     at = AppTest.from_file("../Equation-Generator.py")
     at.run()
@@ -108,6 +117,7 @@ def test_reactions_only_in_advanced_mode():
 
 
 @pytest.mark.ci
+@pytest.mark.unit_test
 def test_bulk_reaction_0D_tank():
     at = AppTest.from_file("../Equation-Generator.py")
     at.run()
@@ -123,6 +133,7 @@ def test_bulk_reaction_0D_tank():
 # === Rapid-equilibrium reaction unit tests ===
 
 @pytest.mark.ci
+@pytest.mark.unit_test
 def test_req_reaction_equation_functions():
     """Unit tests for rapid-equilibrium reaction equation snippet functions."""
     from src import equations as eq
@@ -161,6 +172,7 @@ def test_req_reaction_equation_functions():
 # === Rapid-equilibrium reaction integration tests ===
 
 @pytest.mark.ci
+@pytest.mark.unit_test
 def test_req_reaction_bulk():
     at = setup_app_with_advanced_mode()
     at.selectbox(key="has_reaction_bulk").set_value("Yes").run()
@@ -174,6 +186,7 @@ def test_req_reaction_bulk():
 
 
 @pytest.mark.ci
+@pytest.mark.unit_test
 def test_req_reaction_bulk_no_particles():
     at = setup_app_with_advanced_mode(add_particles="No")
     at.selectbox(key="has_reaction_bulk").set_value("Yes").run()
@@ -185,6 +198,7 @@ def test_req_reaction_bulk_no_particles():
 
 
 @pytest.mark.ci
+@pytest.mark.unit_test
 def test_req_reaction_particle_liquid_1D():
     at = setup_app_with_advanced_mode(particle_resolution="1D (radial coordinate)")
     at.selectbox(key="has_reaction_particle_liquid").set_value("Yes").run()
@@ -197,6 +211,7 @@ def test_req_reaction_particle_liquid_1D():
 
 
 @pytest.mark.ci
+@pytest.mark.unit_test
 def test_req_reaction_particle_solid_1D():
     at = setup_app_with_advanced_mode(particle_resolution="1D (radial coordinate)")
     at.selectbox(key="has_reaction_particle_solid").set_value("Yes").run()
@@ -209,6 +224,7 @@ def test_req_reaction_particle_solid_1D():
 
 
 @pytest.mark.ci
+@pytest.mark.unit_test
 def test_req_reaction_particle_liquid_0D():
     at = setup_app_with_advanced_mode(particle_resolution="0D (homogeneous)")
     at.selectbox(key="has_reaction_particle_liquid").set_value("Yes").run()
@@ -220,6 +236,7 @@ def test_req_reaction_particle_liquid_0D():
 
 
 @pytest.mark.ci
+@pytest.mark.unit_test
 def test_req_reaction_particle_solid_0D():
     at = setup_app_with_advanced_mode(particle_resolution="0D (homogeneous)")
     at.selectbox(key="has_reaction_particle_solid").set_value("Yes").run()
@@ -231,6 +248,7 @@ def test_req_reaction_particle_solid_0D():
 
 
 @pytest.mark.ci
+@pytest.mark.unit_test
 def test_req_reaction_all():
     at = setup_app_with_advanced_mode()
     at.selectbox(key="has_reaction_bulk").set_value("Yes").run()
@@ -248,6 +266,7 @@ def test_req_reaction_all():
 
 
 @pytest.mark.ci
+@pytest.mark.unit_test
 def test_req_reaction_kinetics_mode_not_shown_without_reaction():
     at = setup_app_with_advanced_mode()
     assert not at.exception
@@ -258,6 +277,7 @@ def test_req_reaction_kinetics_mode_not_shown_without_reaction():
 
 
 @pytest.mark.ci
+@pytest.mark.unit_test
 def test_req_reaction_assumptions():
     at = setup_app_with_advanced_mode()
     at.selectbox(key="has_reaction_bulk").set_value("Yes").run()
@@ -269,6 +289,7 @@ def test_req_reaction_assumptions():
 
 
 @pytest.mark.ci
+@pytest.mark.unit_test
 def test_mixed_kinetic_and_req_reactions():
     """Test that kinetic and rapid-equilibrium reactions can coexist in different phases."""
     at = setup_app_with_advanced_mode()
@@ -285,6 +306,7 @@ def test_mixed_kinetic_and_req_reactions():
 
 
 @pytest.mark.ci
+@pytest.mark.unit_test
 def test_req_reaction_bulk_0D_tank():
     """Test rapid-equilibrium bulk reaction in 0D tank model."""
     at = AppTest.from_file("../Equation-Generator.py")
@@ -302,6 +324,7 @@ def test_req_reaction_bulk_0D_tank():
 
 
 @pytest.mark.ci
+@pytest.mark.unit_test
 def test_req_reaction_with_psd():
     """Test rapid-equilibrium reactions with particle size distribution (N_p > 1)."""
     at = AppTest.from_file("../Equation-Generator.py")
@@ -324,6 +347,7 @@ def test_req_reaction_with_psd():
 
 
 @pytest.mark.ci
+@pytest.mark.unit_test
 def test_req_reaction_assumptions_multiple_phases():
     """Test assumptions text lists all phases with rapid-equilibrium reactions."""
     at = setup_app_with_advanced_mode()
@@ -340,6 +364,7 @@ def test_req_reaction_assumptions_multiple_phases():
 
 
 @pytest.mark.ci
+@pytest.mark.unit_test
 def test_req_reaction_symbol_table():
     """Test that symbol table contains rapid-equilibrium reaction symbols."""
     at = setup_app_with_advanced_mode()


### PR DESCRIPTION
Closes #35

## Summary
- Add rapid-equilibrium reaction mode (Kinetic / Rapid-equilibrium) for bulk, particle liquid, and particle solid phases
- Show algebraic equilibrium constraints and conserved moiety matrix formulation when rapid-equilibrium is selected
- Add model assumptions for rapid-equilibrium reactions
- Add 10 new tests covering all phases, mixed modes, and UI behavior

## Test plan
- [x] All 326 tests pass (including 10 new rapid-equilibrium reaction tests)
- [x] No regressions in existing tests