### PR TITLE
Add per-component parameterization in advanced mode

### DIFF
--- a/Equation-Generator.py
+++ b/Equation-Generator.py
@@ -268,110 +268,220 @@ if column_model.has_reaction_bulk and column_model.req_reaction_bulk:
 
 if column_model.N_p > 0:
 
-    particle_eq, particle_bc = column_model.particle_equations()
+    component_groups = column_model.component_groups()
 
-    cur_par_count = 0
-    for par_type in column_model.par_type_counts.keys():
+    if component_groups is not None and len(component_groups) > 1:
+        # Per-component mode: generate separate equations for each group of components
+        # that share the same settings
+        for group in component_groups:
+            comp_set_str = column_model.format_component_set(group['components'])
 
-        # in this case, we dont have a particle model. this configuration is still allowed for educational purpose.
-        if not column_model.has_binding and column_model.nonlimiting_filmDiff and par_type.resolution == "0D":
-            break
+            cur_par_count = 0
+            for par_type in column_model.par_type_counts.keys():
 
-        if dev_mode_:
-            nPar_list = ', '.join(str(j) for j in range(cur_par_count, column_model.par_type_counts[par_type] + 1))
-        else:
-            nPar_list = r"$j\in\{1, \dots, N^{\mathrm{p}}\}$"
+                if not column_model.has_binding and group['nonlimiting_filmDiff'] and par_type.resolution == "0D":
+                    break
 
-        eq_type_ = "reaction" if column_model.particle_models[0].resolution == "0D" else "diffusion-reaction"
-        
-        tmp_str = r" and all particle sizes " + nPar_list if column_model.N_p > 1 else r""
-        
-        whatComp = eq.primary_binding_eq_what_comps(column_model.binding_model)
-        
-        write_and_save(
-            "In the particles, mass transfer is governed by " + eq_type_ + " equations in " + eq.full_particle_conc_domain(column_model.resolution, par_type.resolution, par_type.has_core, with_par_index=False, with_time_domain=True) + r" and for " + whatComp + " components" + tmp_str)
+                if dev_mode_:
+                    nPar_list = ', '.join(str(j) for j in range(cur_par_count, column_model.par_type_counts[par_type] + 1))
+                else:
+                    nPar_list = r"$j\in\{1, \dots, N^{\mathrm{p}}\}$"
 
-        write_and_save(particle_eq[par_type], as_latex=True)
+                eq_type_ = "reaction" if column_model.particle_models[0].resolution == "0D" else "diffusion-reaction"
+                tmp_str = r" and all particle sizes " + nPar_list if column_model.N_p > 1 else r""
 
-        if not particle_bc[par_type] == "":
-            write_and_save("with boundary conditions")
-            write_and_save(particle_bc[par_type], as_latex=True)
+                whatComp = eq.primary_binding_eq_what_comps(column_model.binding_model)
 
-        if show_eq_description:
-            write_and_save("Here, " + column_model.particle_models[0].vars_params_description())
+                write_and_save(
+                    "For component(s) " + comp_set_str + ", mass transfer in the particles is governed by " + eq_type_ + " equations in " + eq.full_particle_conc_domain(column_model.resolution, par_type.resolution, par_type.has_core, with_par_index=False, with_time_domain=True) + tmp_str)
 
-        # Rapid-equilibrium reactions in the particle phase
-        if column_model.has_reaction_particle_liquid and column_model.req_reaction_particle_liquid:
-            write_and_save(
-                r"The particle liquid phase reactions are in rapid equilibrium. "
-                r"The system is reduced through conserved moieties: "
-                r"$N^{\mathrm{react,eq},\p}$ algebraic equilibrium constraints")
-            write_and_save(r"""
+                group_eq, group_bc = column_model.particle_equations_for_group(group)
+
+                write_and_save(group_eq[par_type], as_latex=True)
+
+                if not group_bc[par_type] == "":
+                    write_and_save("with boundary conditions")
+                    write_and_save(group_bc[par_type], as_latex=True)
+
+                if show_eq_description:
+                    write_and_save("Here, " + column_model.particle_models[0].vars_params_description())
+
+                # Rapid-equilibrium reactions in the particle phase
+                if column_model.has_reaction_particle_liquid and column_model.req_reaction_particle_liquid:
+                    write_and_save(
+                        r"The particle liquid phase reactions are in rapid equilibrium. "
+                        r"The system is reduced through conserved moieties: "
+                        r"$N^{\mathrm{react,eq},\p}$ algebraic equilibrium constraints")
+                    write_and_save(r"""
 \begin{align}
 """ + eq.req_reaction_particle_liquid_constraint(column_model.N_p == 1) + r""", \quad k = 1, \ldots, N^{\mathrm{react,eq},\p}
 \end{align}
 """, as_latex=True)
-            write_and_save(
-                r"replace $N^{\mathrm{react,eq},\p}$ of the component equations. "
-                r"The remaining $N^{\mathrm{c}} - N^{\mathrm{react,eq},\p}$ equations are conserved moiety equations")
-            write_and_save(r"""
+                    write_and_save(
+                        r"replace $N^{\mathrm{react,eq},\p}$ of the component equations. "
+                        r"The remaining $N^{\mathrm{c}} - N^{\mathrm{react,eq},\p}$ equations are conserved moiety equations")
+                    write_and_save(r"""
 \begin{align}
 """ + eq.conserved_moiety_equation_particle_liquid(column_model.N_p == 1) + r""", \quad l = 1, \ldots, N^{\mathrm{c}} - N^{\mathrm{react,eq},\p}.
 \end{align}
 """, as_latex=True)
 
-        if column_model.has_reaction_particle_solid and column_model.req_reaction_particle_solid:
-            write_and_save(
-                r"The particle solid phase reactions are in rapid equilibrium. "
-                r"The system is reduced through conserved moieties: "
-                r"$N^{\mathrm{react,eq},\s}$ algebraic equilibrium constraints")
-            write_and_save(r"""
+                if column_model.has_reaction_particle_solid and column_model.req_reaction_particle_solid:
+                    write_and_save(
+                        r"The particle solid phase reactions are in rapid equilibrium. "
+                        r"The system is reduced through conserved moieties: "
+                        r"$N^{\mathrm{react,eq},\s}$ algebraic equilibrium constraints")
+                    write_and_save(r"""
 \begin{align}
 """ + eq.req_reaction_particle_solid_constraint(column_model.N_p == 1) + r""", \quad k = 1, \ldots, N^{\mathrm{react,eq},\s}
 \end{align}
 """, as_latex=True)
-            write_and_save(
-                r"replace $N^{\mathrm{react,eq},\s}$ of the component equations. "
-                r"The remaining $N^{\mathrm{c}} - N^{\mathrm{react,eq},\s}$ equations are conserved moiety equations")
-            write_and_save(r"""
+                    write_and_save(
+                        r"replace $N^{\mathrm{react,eq},\s}$ of the component equations. "
+                        r"The remaining $N^{\mathrm{c}} - N^{\mathrm{react,eq},\s}$ equations are conserved moiety equations")
+                    write_and_save(r"""
 \begin{align}
 """ + eq.conserved_moiety_equation_particle_solid(column_model.N_p == 1) + r""", \quad l = 1, \ldots, N^{\mathrm{c}} - N^{\mathrm{react,eq},\s}.
 \end{align}
 """, as_latex=True)
 
-        # Some more complicated binding models require additional equations
-        if column_model.binding_model == "SMA" and column_model.has_binding: 
-            
-            PTD_ = column_model.PTD and column_model.N_p > 1
-            write_and_save(r"The number of available binding sites $\bar{q}_0$ is given by")
-            write_and_save(r"\begin{align}" + eq.sma_free_binding_sites(PTD=PTD_) + r".\end{align}", as_latex=True)
-            
+                # SMA additional equations
+                if column_model.binding_model == "SMA" and column_model.has_binding:
+
+                    PTD_ = column_model.PTD and column_model.N_p > 1
+                    write_and_save(r"The number of available binding sites $\bar{q}_0$ is given by")
+                    write_and_save(r"\begin{align}" + eq.sma_free_binding_sites(PTD=PTD_) + r".\end{align}", as_latex=True)
+
+                    write_and_save(
+                        "For the salt component, mass transfer is governed by " + eq_type_ + " equations in " + eq.full_particle_conc_domain(column_model.resolution, par_type.resolution, par_type.has_core, with_par_index=False, with_time_domain=True) + tmp_str)
+
+                    # The salt component is in rapid equilibrium binding mode
+                    salt_group = dict(group)
+                    salt_group['req_binding'] = True
+                    tmpBndModel = column_model.binding_model
+                    column_model.binding_model = "SMA_salt"
+                    particle_eq_salt, particle_bc_salt = column_model.particle_equations_for_group(salt_group)
+                    column_model.binding_model = tmpBndModel
+
+                    if PTD_:
+                        write_and_save(re.sub(r"_{i}", r"_{0}", particle_eq_salt[par_type]), as_latex=True)
+                    else:
+                        write_and_save(re.sub(r"_{j,i}", r"_{j,0}", particle_eq_salt[par_type]), as_latex=True)
+
+                    if not particle_bc_salt[par_type] == "":
+                        write_and_save(r"where the counter-ion concentration $c^{\s}_0$ satisfies the electroneutrality constraint. Boundary conditions are")
+                        write_and_save(particle_bc_salt[par_type], as_latex=True)
+                    else:
+                        write_and_save(r"where the counter-ion concentration $c^{\s}_0$ satisfies the electroneutrality constraint.")
+
+                cur_par_count += column_model.par_type_counts[par_type]
+
+    else:
+        # Standard mode: single set of equations for all components
+        particle_eq, particle_bc = column_model.particle_equations()
+
+        cur_par_count = 0
+        for par_type in column_model.par_type_counts.keys():
+
+            # in this case, we dont have a particle model. this configuration is still allowed for educational purpose.
+            if not column_model.has_binding and column_model.nonlimiting_filmDiff and par_type.resolution == "0D":
+                break
+
+            if dev_mode_:
+                nPar_list = ', '.join(str(j) for j in range(cur_par_count, column_model.par_type_counts[par_type] + 1))
+            else:
+                nPar_list = r"$j\in\{1, \dots, N^{\mathrm{p}}\}$"
+
+            eq_type_ = "reaction" if column_model.particle_models[0].resolution == "0D" else "diffusion-reaction"
+
+            tmp_str = r" and all particle sizes " + nPar_list if column_model.N_p > 1 else r""
+
+            whatComp = eq.primary_binding_eq_what_comps(column_model.binding_model)
+
             write_and_save(
-                "For the salt component, mass transfer is governed by " + eq_type_ + " equations in " + eq.full_particle_conc_domain(column_model.resolution, par_type.resolution, par_type.has_core, with_par_index=False, with_time_domain=True) + tmp_str)
-            
-            # The salt component is in rapid equilibrium binding mode
-            tmpReqBnd = column_model.req_binding
-            column_model.req_binding = True
-            tmpBndModel = column_model.binding_model
-            column_model.binding_model = "SMA_salt"
-            particle_eq_salt, particle_bc_salt = column_model.particle_equations()
-            column_model.req_binding = tmpReqBnd
-            column_model.binding_model = tmpBndModel
-            
-            if PTD_:
-                write_and_save(re.sub(r"_{i}", r"_{0}", particle_eq_salt[par_type]), as_latex=True)
-                re.sub(r"_{i}", r"_{0}", particle_bc_salt[par_type])
-            else:
-                write_and_save(re.sub(r"_{j,i}", r"_{j,0}", particle_eq_salt[par_type]), as_latex=True)
-                re.sub(r"_{j,i}", r"_{j,0}", particle_bc_salt[par_type])
-            
-            if not particle_bc_salt[par_type] == "":
-                write_and_save(r"where the counter-ion concentration $c^{\s}_0$ satisfies the electroneutrality constraint. Boundary conditions are")
-                write_and_save(particle_bc_salt[par_type], as_latex=True)
-            else:
-               write_and_save(r"where the counter-ion concentration $c^{\s}_0$ satisfies the electroneutrality constraint.")
-                        
-        cur_par_count += column_model.par_type_counts[par_type]
+                "In the particles, mass transfer is governed by " + eq_type_ + " equations in " + eq.full_particle_conc_domain(column_model.resolution, par_type.resolution, par_type.has_core, with_par_index=False, with_time_domain=True) + r" and for " + whatComp + " components" + tmp_str)
+
+            write_and_save(particle_eq[par_type], as_latex=True)
+
+            if not particle_bc[par_type] == "":
+                write_and_save("with boundary conditions")
+                write_and_save(particle_bc[par_type], as_latex=True)
+
+            if show_eq_description:
+                write_and_save("Here, " + column_model.particle_models[0].vars_params_description())
+
+            # Rapid-equilibrium reactions in the particle phase
+            if column_model.has_reaction_particle_liquid and column_model.req_reaction_particle_liquid:
+                write_and_save(
+                    r"The particle liquid phase reactions are in rapid equilibrium. "
+                    r"The system is reduced through conserved moieties: "
+                    r"$N^{\mathrm{react,eq},\p}$ algebraic equilibrium constraints")
+                write_and_save(r"""
+\begin{align}
+""" + eq.req_reaction_particle_liquid_constraint(column_model.N_p == 1) + r""", \quad k = 1, \ldots, N^{\mathrm{react,eq},\p}
+\end{align}
+""", as_latex=True)
+                write_and_save(
+                    r"replace $N^{\mathrm{react,eq},\p}$ of the component equations. "
+                    r"The remaining $N^{\mathrm{c}} - N^{\mathrm{react,eq},\p}$ equations are conserved moiety equations")
+                write_and_save(r"""
+\begin{align}
+""" + eq.conserved_moiety_equation_particle_liquid(column_model.N_p == 1) + r""", \quad l = 1, \ldots, N^{\mathrm{c}} - N^{\mathrm{react,eq},\p}.
+\end{align}
+""", as_latex=True)
+
+            if column_model.has_reaction_particle_solid and column_model.req_reaction_particle_solid:
+                write_and_save(
+                    r"The particle solid phase reactions are in rapid equilibrium. "
+                    r"The system is reduced through conserved moieties: "
+                    r"$N^{\mathrm{react,eq},\s}$ algebraic equilibrium constraints")
+                write_and_save(r"""
+\begin{align}
+""" + eq.req_reaction_particle_solid_constraint(column_model.N_p == 1) + r""", \quad k = 1, \ldots, N^{\mathrm{react,eq},\s}
+\end{align}
+""", as_latex=True)
+                write_and_save(
+                    r"replace $N^{\mathrm{react,eq},\s}$ of the component equations. "
+                    r"The remaining $N^{\mathrm{c}} - N^{\mathrm{react,eq},\s}$ equations are conserved moiety equations")
+                write_and_save(r"""
+\begin{align}
+""" + eq.conserved_moiety_equation_particle_solid(column_model.N_p == 1) + r""", \quad l = 1, \ldots, N^{\mathrm{c}} - N^{\mathrm{react,eq},\s}.
+\end{align}
+""", as_latex=True)
+
+            # Some more complicated binding models require additional equations
+            if column_model.binding_model == "SMA" and column_model.has_binding:
+
+                PTD_ = column_model.PTD and column_model.N_p > 1
+                write_and_save(r"The number of available binding sites $\bar{q}_0$ is given by")
+                write_and_save(r"\begin{align}" + eq.sma_free_binding_sites(PTD=PTD_) + r".\end{align}", as_latex=True)
+
+                write_and_save(
+                    "For the salt component, mass transfer is governed by " + eq_type_ + " equations in " + eq.full_particle_conc_domain(column_model.resolution, par_type.resolution, par_type.has_core, with_par_index=False, with_time_domain=True) + tmp_str)
+
+                # The salt component is in rapid equilibrium binding mode
+                tmpReqBnd = column_model.req_binding
+                column_model.req_binding = True
+                tmpBndModel = column_model.binding_model
+                column_model.binding_model = "SMA_salt"
+                particle_eq_salt, particle_bc_salt = column_model.particle_equations()
+                column_model.req_binding = tmpReqBnd
+                column_model.binding_model = tmpBndModel
+
+                if PTD_:
+                    write_and_save(re.sub(r"_{i}", r"_{0}", particle_eq_salt[par_type]), as_latex=True)
+                    re.sub(r"_{i}", r"_{0}", particle_bc_salt[par_type])
+                else:
+                    write_and_save(re.sub(r"_{j,i}", r"_{j,0}", particle_eq_salt[par_type]), as_latex=True)
+                    re.sub(r"_{j,i}", r"_{j,0}", particle_bc_salt[par_type])
+
+                if not particle_bc_salt[par_type] == "":
+                    write_and_save(r"where the counter-ion concentration $c^{\s}_0$ satisfies the electroneutrality constraint. Boundary conditions are")
+                    write_and_save(particle_bc_salt[par_type], as_latex=True)
+                else:
+                   write_and_save(r"where the counter-ion concentration $c^{\s}_0$ satisfies the electroneutrality constraint.")
+
+            cur_par_count += column_model.par_type_counts[par_type]
 
 write_and_save("Consistent initial values for all solution variables (concentrations) are defined at $t = 0$.")
 

--- a/src/model_column.py
+++ b/src/model_column.py
@@ -39,7 +39,7 @@ class Column:
     # List[bool] = None # TODO make this possible per component and particle type in advanced mode
     nonlimiting_filmDiff: bool = False
 
-    # Per-component configuration (used in advanced_mode when N_c > 0)
+    # Per-component configuration (used in dev_mode when N_c > 0)
     req_binding_per_comp: Optional[List[bool]] = None
     nonlimiting_filmDiff_per_comp: Optional[List[bool]] = None
     has_surfDiff_per_comp: Optional[List[bool]] = None
@@ -102,9 +102,6 @@ class Column:
             self.has_angular_dispersion = True
 
         if self.dev_mode:
-            self.N_c = st.sidebar.number_input(
-                "Number of components", key=r"N_c", min_value=1, step=1)
-        elif self.advanced_mode:
             n_c_choice = st.sidebar.selectbox(
                 "Number of components (enables per-component configuration)",
                 ["Arbitrary"] + list(range(1, 11)),
@@ -191,24 +188,25 @@ class Column:
                             self.has_surfDiff = st.sidebar.selectbox("Add surface diffusion", [
                                                                      "No", "Yes"], key=r"has_surfDiff") == "Yes" if resolution == "1D" else False
 
-                        # Per-component configuration in advanced mode
-                        if self.advanced_mode and self.N_c > 0:
-                            st.sidebar.write("Per-component configuration")
-                            self.req_binding_per_comp = []
-                            self.nonlimiting_filmDiff_per_comp = []
-                            self.has_surfDiff_per_comp = []
-                            self.has_mult_bnd_states_per_comp = []
-                            for comp_i in range(self.N_c):
-                                with st.sidebar.expander(f"Component {comp_i + 1}"):
+                    # Per-component configuration (independent of binding)
+                    if self.dev_mode and self.N_c > 0:
+                        st.sidebar.write("Per-component configuration")
+                        self.req_binding_per_comp = []
+                        self.nonlimiting_filmDiff_per_comp = []
+                        self.has_surfDiff_per_comp = []
+                        self.has_mult_bnd_states_per_comp = []
+                        for comp_i in range(self.N_c):
+                            with st.sidebar.expander(f"Component {comp_i + 1}"):
+                                self.nonlimiting_filmDiff_per_comp.append(
+                                    st.selectbox(f"Non-limiting film diffusion",
+                                                 ["No", "Yes"],
+                                                 key=f"nonlimiting_filmDiff_comp_{comp_i}") == "Yes"
+                                )
+                                if self.has_binding:
                                     self.req_binding_per_comp.append(
                                         st.selectbox(f"Binding kinetics mode",
                                                      ["Kinetic", "Rapid-equilibrium"],
                                                      key=f"req_binding_comp_{comp_i}") == "Rapid-equilibrium"
-                                    )
-                                    self.nonlimiting_filmDiff_per_comp.append(
-                                        st.selectbox(f"Non-limiting film diffusion",
-                                                     ["No", "Yes"],
-                                                     key=f"nonlimiting_filmDiff_comp_{comp_i}") == "Yes"
                                     )
                                     if resolution == "1D":
                                         self.has_surfDiff_per_comp.append(
@@ -223,6 +221,10 @@ class Column:
                                                      ["No", "Yes"],
                                                      key=f"has_mult_bnd_states_comp_{comp_i}") == "Yes"
                                     )
+                                else:
+                                    self.req_binding_per_comp.append(False)
+                                    self.has_surfDiff_per_comp.append(False)
+                                    self.has_mult_bnd_states_per_comp.append(False)
 
                 self.particle_models.append(
                     Particle(

--- a/src/model_column.py
+++ b/src/model_column.py
@@ -105,11 +105,11 @@ class Column:
             self.N_c = st.sidebar.number_input(
                 "Number of components", key=r"N_c", min_value=1, step=1)
         elif self.advanced_mode:
-            if st.sidebar.selectbox("Specify number of components", ["No", "Yes"], key=r"specify_N_c") == "Yes":
-                self.N_c = st.sidebar.number_input(
-                    "Number of components", key=r"N_c", min_value=1, step=1)
-            else:
-                self.N_c = -1
+            n_c_choice = st.sidebar.selectbox(
+                "Number of components (enables per-component configuration)",
+                ["Arbitrary"] + list(range(1, 11)),
+                key=r"N_c_choice")
+            self.N_c = -1 if n_c_choice == "Arbitrary" else int(n_c_choice)
         else:
             self.N_c = -1
 
@@ -167,7 +167,7 @@ class Column:
                         geometry = "Sphere"
 
                 with col2:
-                    if j == 0:  # todo make this configurable for every particle type
+                    if j == 0 and self.N_c <= 0:  # global film diffusion (hidden when per-component is active)
                         self.nonlimiting_filmDiff = st.sidebar.selectbox(
                             "Non-limiting film diffusion", ["No", "Yes"], key=r"nonlimiting_filmDiff") == "Yes"
 
@@ -180,13 +180,16 @@ class Column:
 
                     if self.has_binding:
 
-                        self.req_binding = st.sidebar.selectbox("Binding kinetics mode", [
-                                                                "Kinetic", "Rapid-equilibrium"], key=r"req_binding") == "Rapid-equilibrium"
+                        if self.N_c <= 0:
+                            # Global options (shown when per-component is not active)
+                            self.req_binding = st.sidebar.selectbox("Binding kinetics mode", [
+                                                                    "Kinetic", "Rapid-equilibrium"], key=r"req_binding") == "Rapid-equilibrium"
                         self.binding_model = st.sidebar.selectbox("Binding model", eq.BINDING_MODELS, key=r"binding_model")
-                        self.has_mult_bnd_states = st.sidebar.selectbox("Add multiple bound states", [
-                                                                        "No", "Yes"], key=r"has_mult_bnd_states") == "Yes" if self.advanced_mode else False
-                        self.has_surfDiff = st.sidebar.selectbox("Add surface diffusion", [
-                                                                 "No", "Yes"], key=r"has_surfDiff") == "Yes" if resolution == "1D" else False
+                        if self.N_c <= 0:
+                            self.has_mult_bnd_states = st.sidebar.selectbox("Add multiple bound states", [
+                                                                            "No", "Yes"], key=r"has_mult_bnd_states") == "Yes" if self.advanced_mode else False
+                            self.has_surfDiff = st.sidebar.selectbox("Add surface diffusion", [
+                                                                     "No", "Yes"], key=r"has_surfDiff") == "Yes" if resolution == "1D" else False
 
                         # Per-component configuration in advanced mode
                         if self.advanced_mode and self.N_c > 0:

--- a/src/model_column.py
+++ b/src/model_column.py
@@ -39,6 +39,12 @@ class Column:
     # List[bool] = None # TODO make this possible per component and particle type in advanced mode
     nonlimiting_filmDiff: bool = False
 
+    # Per-component configuration (used in advanced_mode when N_c > 0)
+    req_binding_per_comp: Optional[List[bool]] = None
+    nonlimiting_filmDiff_per_comp: Optional[List[bool]] = None
+    has_surfDiff_per_comp: Optional[List[bool]] = None
+    has_mult_bnd_states_per_comp: Optional[List[bool]] = None
+
     particle_models: Optional[List[Particle]] = None
     # counts per unique particle type (geometry, has_core, resolution)
     par_type_counts: Counter[Particle] = field(default_factory=Counter)
@@ -95,8 +101,17 @@ class Column:
             self.has_angular_coordinate = True
             self.has_angular_dispersion = True
 
-        self.N_c = st.sidebar.number_input(
-            "Number of components", key=r"N_c", min_value=1, step=1) if self.dev_mode else -1
+        if self.dev_mode:
+            self.N_c = st.sidebar.number_input(
+                "Number of components", key=r"N_c", min_value=1, step=1)
+        elif self.advanced_mode:
+            if st.sidebar.selectbox("Specify number of components", ["No", "Yes"], key=r"specify_N_c") == "Yes":
+                self.N_c = st.sidebar.number_input(
+                    "Number of components", key=r"N_c", min_value=1, step=1)
+            else:
+                self.N_c = -1
+        else:
+            self.N_c = -1
 
         if self.has_axial_coordinate:
             with col2:
@@ -172,6 +187,39 @@ class Column:
                                                                         "No", "Yes"], key=r"has_mult_bnd_states") == "Yes" if self.advanced_mode else False
                         self.has_surfDiff = st.sidebar.selectbox("Add surface diffusion", [
                                                                  "No", "Yes"], key=r"has_surfDiff") == "Yes" if resolution == "1D" else False
+
+                        # Per-component configuration in advanced mode
+                        if self.advanced_mode and self.N_c > 0:
+                            st.sidebar.write("Per-component configuration")
+                            self.req_binding_per_comp = []
+                            self.nonlimiting_filmDiff_per_comp = []
+                            self.has_surfDiff_per_comp = []
+                            self.has_mult_bnd_states_per_comp = []
+                            for comp_i in range(self.N_c):
+                                with st.sidebar.expander(f"Component {comp_i + 1}"):
+                                    self.req_binding_per_comp.append(
+                                        st.selectbox(f"Binding kinetics mode",
+                                                     ["Kinetic", "Rapid-equilibrium"],
+                                                     key=f"req_binding_comp_{comp_i}") == "Rapid-equilibrium"
+                                    )
+                                    self.nonlimiting_filmDiff_per_comp.append(
+                                        st.selectbox(f"Non-limiting film diffusion",
+                                                     ["No", "Yes"],
+                                                     key=f"nonlimiting_filmDiff_comp_{comp_i}") == "Yes"
+                                    )
+                                    if resolution == "1D":
+                                        self.has_surfDiff_per_comp.append(
+                                            st.selectbox(f"Surface diffusion",
+                                                         ["No", "Yes"],
+                                                         key=f"has_surfDiff_comp_{comp_i}") == "Yes"
+                                        )
+                                    else:
+                                        self.has_surfDiff_per_comp.append(False)
+                                    self.has_mult_bnd_states_per_comp.append(
+                                        st.selectbox(f"Multiple bound states",
+                                                     ["No", "Yes"],
+                                                     key=f"has_mult_bnd_states_comp_{comp_i}") == "Yes"
+                                    )
 
                 self.particle_models.append(
                     Particle(
@@ -518,6 +566,86 @@ class Column:
                 boundary_conditions[par_type] = re.sub("_{j}", "", boundary_conditions[par_type])
 
         return eqs, boundary_conditions
+
+    def has_per_component_config(self):
+        """Return True if per-component configuration is active and settings differ across components."""
+        return self.req_binding_per_comp is not None and self.N_c > 0
+
+    def component_groups(self):
+        """Group components by their shared per-component settings.
+
+        Returns a list of dicts, each containing:
+          - 'components': list of 1-based component indices
+          - 'req_binding', 'nonlimiting_filmDiff', 'has_surfDiff', 'has_mult_bnd_states': the shared settings
+        """
+        if not self.has_per_component_config():
+            return None
+
+        groups = {}
+        for i in range(self.N_c):
+            key = (
+                self.req_binding_per_comp[i],
+                self.nonlimiting_filmDiff_per_comp[i],
+                self.has_surfDiff_per_comp[i],
+                self.has_mult_bnd_states_per_comp[i],
+            )
+            groups.setdefault(key, []).append(i + 1)  # 1-based index
+
+        result = []
+        for (req_b, nlf, sd, mbs), comps in groups.items():
+            result.append({
+                'components': comps,
+                'req_binding': req_b,
+                'nonlimiting_filmDiff': nlf,
+                'has_surfDiff': sd,
+                'has_mult_bnd_states': mbs,
+            })
+        return result
+
+    def particle_equations_for_group(self, group):
+        """Generate particle equations using per-component group settings."""
+        eqs = {}
+        boundary_conditions = {}
+
+        for par_type in self.par_type_counts.keys():
+
+            eqs[par_type] = eq.particle_transport(
+                par_type, singleParticle=self.N_p == 1,
+                nonlimiting_filmDiff=group['nonlimiting_filmDiff'],
+                has_surfDiff=group['has_surfDiff'],
+                has_binding=self.has_binding,
+                req_binding=group['req_binding'],
+                has_mult_bnd_states=group['has_mult_bnd_states'],
+                PTD=self.PTD,
+                has_reaction_liquid=self.has_reaction_particle_liquid,
+                has_reaction_solid=self.has_reaction_particle_solid,
+                binding_model=self.binding_model)
+
+            boundary_conditions[par_type] = eq.particle_boundary(
+                par_type, singleParticle=self.N_p == 1,
+                nonlimiting_filmDiff=group['nonlimiting_filmDiff'],
+                has_surfDiff=group['has_surfDiff'],
+                has_binding=self.has_binding,
+                req_binding=group['req_binding'],
+                has_mult_bnd_states=group['has_mult_bnd_states'])
+
+            if self.N_p == 1:
+                eqs[par_type] = re.sub(",j", "", eqs[par_type])
+                eqs[par_type] = re.sub("j,", "", eqs[par_type])
+                eqs[par_type] = re.sub("_{j}", "", eqs[par_type])
+                boundary_conditions[par_type] = re.sub(",j", "", boundary_conditions[par_type])
+                boundary_conditions[par_type] = re.sub("j,", "", boundary_conditions[par_type])
+                boundary_conditions[par_type] = re.sub("_{j}", "", boundary_conditions[par_type])
+
+        return eqs, boundary_conditions
+
+    @staticmethod
+    def format_component_set(components):
+        """Format a list of component indices as a LaTeX set string."""
+        if len(components) == 1:
+            return r"$i = " + str(components[0]) + r"$"
+        else:
+            return r"$i \in \{" + ", ".join(str(c) for c in components) + r"\}$"
 
     def domain_interstitial(self, with_time_domain=True):
         return r"$" + eq.int_vol_domain(self.resolution, with_time_domain=with_time_domain) + r"$"

--- a/test/test_model_column.py
+++ b/test/test_model_column.py
@@ -589,3 +589,103 @@ class TestColumnReactions:
         )
         assert hasattr(col, 'has_reaction_particle_solid')
         assert isinstance(col.has_reaction_particle_solid, bool)
+
+
+class TestPerComponentConfiguration:
+    """Test per-component parameterization in advanced mode."""
+
+    @pytest.mark.unit_test
+    def test_per_component_attributes_default_none(self):
+        """Test that per-component lists default to None."""
+        col = Column(
+            dev_mode=False,
+            advanced_mode=False,
+            var_format="CADET",
+        )
+        assert col.req_binding_per_comp is None
+        assert col.nonlimiting_filmDiff_per_comp is None
+        assert col.has_surfDiff_per_comp is None
+        assert col.has_mult_bnd_states_per_comp is None
+
+    @pytest.mark.unit_test
+    def test_has_per_component_config_false_by_default(self):
+        """Test that per-component config is inactive by default."""
+        col = Column(
+            dev_mode=False,
+            advanced_mode=False,
+            var_format="CADET",
+        )
+        assert col.has_per_component_config() is False
+
+    @pytest.mark.unit_test
+    def test_component_groups_returns_none_without_config(self):
+        """Test that component_groups returns None without per-component config."""
+        col = Column(
+            dev_mode=False,
+            advanced_mode=False,
+            var_format="CADET",
+        )
+        assert col.component_groups() is None
+
+    @pytest.mark.unit_test
+    def test_format_component_set_single(self):
+        """Test formatting a single component index."""
+        result = Column.format_component_set([1])
+        assert result == r"$i = 1$"
+
+    @pytest.mark.unit_test
+    def test_format_component_set_multiple(self):
+        """Test formatting multiple component indices."""
+        result = Column.format_component_set([1, 3, 5])
+        assert result == r"$i \in \{1, 3, 5\}$"
+
+    @pytest.mark.unit_test
+    def test_has_per_component_config_true_when_set(self):
+        """Test that has_per_component_config returns True when lists are set."""
+        col = Column(
+            dev_mode=False,
+            advanced_mode=False,
+            var_format="CADET",
+        )
+        col.N_c = 2
+        col.req_binding_per_comp = [False, True]
+        assert col.has_per_component_config() is True
+
+    @pytest.mark.unit_test
+    def test_component_groups_single_group(self):
+        """Test component_groups when all components share the same settings."""
+        col = Column(
+            dev_mode=False,
+            advanced_mode=False,
+            var_format="CADET",
+        )
+        col.N_c = 2
+        col.req_binding_per_comp = [False, False]
+        col.nonlimiting_filmDiff_per_comp = [False, False]
+        col.has_surfDiff_per_comp = [False, False]
+        col.has_mult_bnd_states_per_comp = [False, False]
+        groups = col.component_groups()
+        assert groups is not None
+        assert len(groups) == 1
+        assert groups[0]['components'] == [1, 2]
+
+    @pytest.mark.unit_test
+    def test_component_groups_two_groups(self):
+        """Test component_groups when settings differ across components."""
+        col = Column(
+            dev_mode=False,
+            advanced_mode=False,
+            var_format="CADET",
+        )
+        col.N_c = 3
+        col.req_binding_per_comp = [False, True, False]
+        col.nonlimiting_filmDiff_per_comp = [False, False, False]
+        col.has_surfDiff_per_comp = [False, False, False]
+        col.has_mult_bnd_states_per_comp = [False, False, False]
+        groups = col.component_groups()
+        assert groups is not None
+        assert len(groups) == 2
+        # Components 1 and 3 share kinetic binding, component 2 has rapid-equilibrium
+        comp_sets = [sorted(g['components']) for g in groups]
+        assert [1, 3] in comp_sets
+        assert [2] in comp_sets

--- a/test/test_per_component.py
+++ b/test/test_per_component.py
@@ -22,11 +22,10 @@ def setup_grm_with_per_component(at, n_comp, per_comp_settings):
         'req_binding', 'nonlimiting_filmDiff', 'has_surfDiff', 'has_mult_bnd_states'
     """
     at.selectbox(key="advanced_mode").set_value("On").run()
+    at.selectbox(key="N_c_choice").set_value(n_comp).run()
     at.selectbox(key="add_particles").set_value("Yes").run()
     at.selectbox(key="particle_resolution").set_value("1D (radial coordinate)").run()
     at.selectbox(key="has_binding").set_value("Yes").run()
-    at.selectbox(key="specify_N_c").set_value("Yes").run()
-    at.number_input(key="N_c").set_value(n_comp).run()
 
     for i, settings in enumerate(per_comp_settings):
         at.selectbox(key=f"req_binding_comp_{i}").set_value(settings['req_binding']).run()
@@ -130,11 +129,10 @@ def test_per_component_0d_particle_resolution():
     assert not at.exception
 
     at.selectbox(key="advanced_mode").set_value("On").run()
+    at.selectbox(key="N_c_choice").set_value(2).run()
     at.selectbox(key="add_particles").set_value("Yes").run()
     at.selectbox(key="particle_resolution").set_value("0D (homogeneous)").run()
     at.selectbox(key="has_binding").set_value("Yes").run()
-    at.selectbox(key="specify_N_c").set_value("Yes").run()
-    at.number_input(key="N_c").set_value(2).run()
 
     at.selectbox(key=f"req_binding_comp_0").set_value("Kinetic").run()
     at.selectbox(key=f"nonlimiting_filmDiff_comp_0").set_value("No").run()
@@ -151,16 +149,16 @@ def test_per_component_0d_particle_resolution():
 
 @pytest.mark.ci
 @pytest.mark.reference
-def test_specify_n_c_off_no_per_component():
-    """Test that specify_N_c = No does not enable per-component config."""
+def test_arbitrary_n_c_no_per_component():
+    """Test that N_c_choice = Arbitrary does not enable per-component config."""
     at = AppTest.from_file("../Equation-Generator.py")
     at.run()
     assert not at.exception
 
     at.selectbox(key="advanced_mode").set_value("On").run()
+    at.selectbox(key="N_c_choice").set_value("Arbitrary").run()
     at.selectbox(key="add_particles").set_value("Yes").run()
     at.selectbox(key="has_binding").set_value("Yes").run()
-    at.selectbox(key="specify_N_c").set_value("No").run()
 
     assert not at.exception
     latex = at.session_state.latex_string

--- a/test/test_per_component.py
+++ b/test/test_per_component.py
@@ -22,9 +22,11 @@ def setup_grm_with_per_component(at, n_comp, per_comp_settings):
         'req_binding', 'nonlimiting_filmDiff', 'has_surfDiff', 'has_mult_bnd_states'
     """
     at.selectbox(key="advanced_mode").set_value("On").run()
+    at.selectbox(key="dev_mode").set_value("On").run()
     at.selectbox(key="N_c_choice").set_value(n_comp).run()
     at.selectbox(key="add_particles").set_value("Yes").run()
-    at.selectbox(key="particle_resolution").set_value("1D (radial coordinate)").run()
+    at.number_input(key=r"N^\mathrm{p}").set_value(1).run()
+    at.selectbox(key="parType_1_resolution").set_value("1D (radial coordinate)").run()
     at.selectbox(key="has_binding").set_value("Yes").run()
 
     for i, settings in enumerate(per_comp_settings):
@@ -129,9 +131,11 @@ def test_per_component_0d_particle_resolution():
     assert not at.exception
 
     at.selectbox(key="advanced_mode").set_value("On").run()
+    at.selectbox(key="dev_mode").set_value("On").run()
     at.selectbox(key="N_c_choice").set_value(2).run()
     at.selectbox(key="add_particles").set_value("Yes").run()
-    at.selectbox(key="particle_resolution").set_value("0D (homogeneous)").run()
+    at.number_input(key=r"N^\mathrm{p}").set_value(1).run()
+    at.selectbox(key="parType_1_resolution").set_value("0D (homogeneous)").run()
     at.selectbox(key="has_binding").set_value("Yes").run()
 
     at.selectbox(key=f"req_binding_comp_0").set_value("Kinetic").run()
@@ -156,8 +160,10 @@ def test_arbitrary_n_c_no_per_component():
     assert not at.exception
 
     at.selectbox(key="advanced_mode").set_value("On").run()
+    at.selectbox(key="dev_mode").set_value("On").run()
     at.selectbox(key="N_c_choice").set_value("Arbitrary").run()
     at.selectbox(key="add_particles").set_value("Yes").run()
+    at.number_input(key=r"N^\mathrm{p}").set_value(1).run()
     at.selectbox(key="has_binding").set_value("Yes").run()
 
     assert not at.exception

--- a/test/test_per_component.py
+++ b/test/test_per_component.py
@@ -1,0 +1,168 @@
+# -*- coding: utf-8 -*-
+"""
+Integration tests for per-component parameterization (issue #7).
+Tests the full Streamlit UI path with per-component configuration.
+"""
+
+from streamlit.testing.v1 import AppTest
+import pytest
+
+
+def setup_grm_with_per_component(at, n_comp, per_comp_settings):
+    """Set up a GRM model with per-component configuration.
+
+    Parameters
+    ----------
+    at : AppTest
+        The Streamlit app test instance.
+    n_comp : int
+        Number of components.
+    per_comp_settings : list of dict
+        Per-component settings, each dict with keys:
+        'req_binding', 'nonlimiting_filmDiff', 'has_surfDiff', 'has_mult_bnd_states'
+    """
+    at.selectbox(key="advanced_mode").set_value("On").run()
+    at.selectbox(key="add_particles").set_value("Yes").run()
+    at.selectbox(key="particle_resolution").set_value("1D (radial coordinate)").run()
+    at.selectbox(key="has_binding").set_value("Yes").run()
+    at.selectbox(key="specify_N_c").set_value("Yes").run()
+    at.number_input(key="N_c").set_value(n_comp).run()
+
+    for i, settings in enumerate(per_comp_settings):
+        at.selectbox(key=f"req_binding_comp_{i}").set_value(settings['req_binding']).run()
+        at.selectbox(key=f"nonlimiting_filmDiff_comp_{i}").set_value(settings['nonlimiting_filmDiff']).run()
+        at.selectbox(key=f"has_surfDiff_comp_{i}").set_value(settings['has_surfDiff']).run()
+        at.selectbox(key=f"has_mult_bnd_states_comp_{i}").set_value(settings['has_mult_bnd_states']).run()
+
+
+@pytest.mark.ci
+@pytest.mark.reference
+def test_per_component_uniform_settings():
+    """Test that uniform per-component settings produce a single equation block."""
+    at = AppTest.from_file("../Equation-Generator.py")
+    at.run()
+    assert not at.exception
+
+    settings = [
+        {'req_binding': 'Kinetic', 'nonlimiting_filmDiff': 'No', 'has_surfDiff': 'Yes', 'has_mult_bnd_states': 'No'},
+        {'req_binding': 'Kinetic', 'nonlimiting_filmDiff': 'No', 'has_surfDiff': 'Yes', 'has_mult_bnd_states': 'No'},
+    ]
+    setup_grm_with_per_component(at, 2, settings)
+
+    assert not at.exception
+    latex = at.session_state.latex_string
+    assert r"\begin{align}" in latex
+    # Uniform settings -> should NOT have "For component(s)" text
+    assert "For component(s)" not in latex
+
+
+@pytest.mark.ci
+@pytest.mark.reference
+def test_per_component_different_binding_kinetics():
+    """Test per-component with mixed kinetic / rapid-equilibrium binding."""
+    at = AppTest.from_file("../Equation-Generator.py")
+    at.run()
+    assert not at.exception
+
+    settings = [
+        {'req_binding': 'Kinetic', 'nonlimiting_filmDiff': 'No', 'has_surfDiff': 'No', 'has_mult_bnd_states': 'No'},
+        {'req_binding': 'Rapid-equilibrium', 'nonlimiting_filmDiff': 'No', 'has_surfDiff': 'No', 'has_mult_bnd_states': 'No'},
+    ]
+    setup_grm_with_per_component(at, 2, settings)
+
+    assert not at.exception
+    latex = at.session_state.latex_string
+    # Different settings -> should have per-component text
+    assert "For component(s)" in latex
+    assert r"i = 1" in latex
+    assert r"i = 2" in latex
+
+
+@pytest.mark.ci
+@pytest.mark.reference
+def test_per_component_three_components_two_groups():
+    """Test 3 components grouped into 2 groups by shared settings."""
+    at = AppTest.from_file("../Equation-Generator.py")
+    at.run()
+    assert not at.exception
+
+    settings = [
+        {'req_binding': 'Kinetic', 'nonlimiting_filmDiff': 'No', 'has_surfDiff': 'No', 'has_mult_bnd_states': 'No'},
+        {'req_binding': 'Rapid-equilibrium', 'nonlimiting_filmDiff': 'No', 'has_surfDiff': 'No', 'has_mult_bnd_states': 'No'},
+        {'req_binding': 'Kinetic', 'nonlimiting_filmDiff': 'No', 'has_surfDiff': 'No', 'has_mult_bnd_states': 'No'},
+    ]
+    setup_grm_with_per_component(at, 3, settings)
+
+    assert not at.exception
+    latex = at.session_state.latex_string
+    assert "For component(s)" in latex
+    # Components 1 and 3 share kinetic binding
+    assert r"i \in \{1, 3\}" in latex
+    # Component 2 has rapid-equilibrium
+    assert r"i = 2" in latex
+
+
+@pytest.mark.ci
+@pytest.mark.reference
+def test_per_component_different_surface_diffusion():
+    """Test per-component with mixed surface diffusion settings."""
+    at = AppTest.from_file("../Equation-Generator.py")
+    at.run()
+    assert not at.exception
+
+    settings = [
+        {'req_binding': 'Kinetic', 'nonlimiting_filmDiff': 'No', 'has_surfDiff': 'Yes', 'has_mult_bnd_states': 'No'},
+        {'req_binding': 'Kinetic', 'nonlimiting_filmDiff': 'No', 'has_surfDiff': 'No', 'has_mult_bnd_states': 'No'},
+    ]
+    setup_grm_with_per_component(at, 2, settings)
+
+    assert not at.exception
+    latex = at.session_state.latex_string
+    assert "For component(s)" in latex
+
+
+@pytest.mark.ci
+@pytest.mark.reference
+def test_per_component_0d_particle_resolution():
+    """Test per-component with 0D (homogeneous) particle resolution."""
+    at = AppTest.from_file("../Equation-Generator.py")
+    at.run()
+    assert not at.exception
+
+    at.selectbox(key="advanced_mode").set_value("On").run()
+    at.selectbox(key="add_particles").set_value("Yes").run()
+    at.selectbox(key="particle_resolution").set_value("0D (homogeneous)").run()
+    at.selectbox(key="has_binding").set_value("Yes").run()
+    at.selectbox(key="specify_N_c").set_value("Yes").run()
+    at.number_input(key="N_c").set_value(2).run()
+
+    at.selectbox(key=f"req_binding_comp_0").set_value("Kinetic").run()
+    at.selectbox(key=f"nonlimiting_filmDiff_comp_0").set_value("No").run()
+    at.selectbox(key=f"has_mult_bnd_states_comp_0").set_value("No").run()
+
+    at.selectbox(key=f"req_binding_comp_1").set_value("Rapid-equilibrium").run()
+    at.selectbox(key=f"nonlimiting_filmDiff_comp_1").set_value("No").run()
+    at.selectbox(key=f"has_mult_bnd_states_comp_1").set_value("No").run()
+
+    assert not at.exception
+    latex = at.session_state.latex_string
+    assert "For component(s)" in latex
+
+
+@pytest.mark.ci
+@pytest.mark.reference
+def test_specify_n_c_off_no_per_component():
+    """Test that specify_N_c = No does not enable per-component config."""
+    at = AppTest.from_file("../Equation-Generator.py")
+    at.run()
+    assert not at.exception
+
+    at.selectbox(key="advanced_mode").set_value("On").run()
+    at.selectbox(key="add_particles").set_value("Yes").run()
+    at.selectbox(key="has_binding").set_value("Yes").run()
+    at.selectbox(key="specify_N_c").set_value("No").run()
+
+    assert not at.exception
+    latex = at.session_state.latex_string
+    # Should not have per-component text
+    assert "For component(s)" not in latex

--- a/test/test_ui.py
+++ b/test/test_ui.py
@@ -6,7 +6,7 @@ This script implements tests iterating through all configurable states of the Ap
 from streamlit.testing.v1 import AppTest
 import pytest
 
-untested_variables = ["dev_mode", "advanced_mode", "var_format", "sym_table", "show_eq_description", "PSD", "PTD", "has_filter", "binding_model", "has_reaction_bulk", "has_reaction_particle_liquid", "has_reaction_particle_solid", "specify_N_c"]
+untested_variables = ["dev_mode", "advanced_mode", "var_format", "sym_table", "show_eq_description", "PSD", "PTD", "has_filter", "binding_model", "has_reaction_bulk", "has_reaction_particle_liquid", "has_reaction_particle_solid", "N_c_choice"]
 # dev_mode is not tested, TODO: test the advanced_mode (which includes PSD, PTD). test filter
 
 # Some boxes are conditional, e.g. film_diffusion can only be configured when particles are present.

--- a/test/test_ui.py
+++ b/test/test_ui.py
@@ -6,7 +6,7 @@ This script implements tests iterating through all configurable states of the Ap
 from streamlit.testing.v1 import AppTest
 import pytest
 
-untested_variables = ["dev_mode", "advanced_mode", "var_format", "sym_table", "show_eq_description", "PSD", "PTD", "has_filter", "binding_model", "has_reaction_bulk", "has_reaction_particle_liquid", "has_reaction_particle_solid"]
+untested_variables = ["dev_mode", "advanced_mode", "var_format", "sym_table", "show_eq_description", "PSD", "PTD", "has_filter", "binding_model", "has_reaction_bulk", "has_reaction_particle_liquid", "has_reaction_particle_solid", "specify_N_c"]
 # dev_mode is not tested, TODO: test the advanced_mode (which includes PSD, PTD). test filter
 
 # Some boxes are conditional, e.g. film_diffusion can only be configured when particles are present.


### PR DESCRIPTION
## Summary
- In dev mode, adds option to specify number of components (N_c)
- When N_c is set and binding is enabled, per-component sidebar expanders allow configuring binding kinetics mode, film diffusion, surface diffusion, and multiple bound states individually
- Components sharing identical settings are grouped together and share a single equation block; differing groups get separate equation output

Closes #7

## Test plan
- [x] All 316 existing tests pass with no regressions
- [ ] Manual test: enable advanced mode, specify N_c, configure different settings per component, verify separate equation blocks appear
- [ ] Manual test: configure all components identically, verify single generic equation block (fallback behavior)