### PR TITLE
Add radial flow and frustum column geometries

### DIFF
--- a/Equation-Generator.py
+++ b/Equation-Generator.py
@@ -297,7 +297,7 @@ if column_model.N_p > 0:
                 whatComp = eq.primary_binding_eq_what_comps(column_model.binding_model)
 
                 write_and_save(
-                    "For component(s) " + comp_set_str + ", mass transfer in the particles is governed by " + eq_type_ + " equations in " + eq.full_particle_conc_domain(column_model.resolution, par_type.resolution, par_type.has_core, with_par_index=False, with_time_domain=True) + tmp_str)
+                    "For component(s) " + comp_set_str + ", mass transfer in the particles is governed by " + eq_type_ + " equations in " + eq.full_particle_conc_domain(column_model.resolution, par_type.resolution, par_type.has_core, with_par_index=False, with_time_domain=True, column_type=column_model.column_type) + tmp_str)
 
                 group_eq, group_bc = column_model.particle_equations_for_group(group)
 
@@ -357,7 +357,7 @@ if column_model.N_p > 0:
                     write_and_save(r"\begin{align}" + eq.sma_free_binding_sites(PTD=PTD_) + r".\end{align}", as_latex=True)
 
                     write_and_save(
-                        "For the salt component, mass transfer is governed by " + eq_type_ + " equations in " + eq.full_particle_conc_domain(column_model.resolution, par_type.resolution, par_type.has_core, with_par_index=False, with_time_domain=True) + tmp_str)
+                        "For the salt component, mass transfer is governed by " + eq_type_ + " equations in " + eq.full_particle_conc_domain(column_model.resolution, par_type.resolution, par_type.has_core, with_par_index=False, with_time_domain=True, column_type=column_model.column_type) + tmp_str)
 
                     # The salt component is in rapid equilibrium binding mode
                     salt_group = dict(group)
@@ -403,7 +403,7 @@ if column_model.N_p > 0:
             whatComp = eq.primary_binding_eq_what_comps(column_model.binding_model)
 
             write_and_save(
-                "In the particles, mass transfer is governed by " + eq_type_ + " equations in " + eq.full_particle_conc_domain(column_model.resolution, par_type.resolution, par_type.has_core, with_par_index=False, with_time_domain=True) + r" and for " + whatComp + " components" + tmp_str)
+                "In the particles, mass transfer is governed by " + eq_type_ + " equations in " + eq.full_particle_conc_domain(column_model.resolution, par_type.resolution, par_type.has_core, with_par_index=False, with_time_domain=True, column_type=column_model.column_type) + r" and for " + whatComp + " components" + tmp_str)
 
             write_and_save(particle_eq[par_type], as_latex=True)
 
@@ -461,7 +461,7 @@ if column_model.N_p > 0:
                 write_and_save(r"\begin{align}" + eq.sma_free_binding_sites(PTD=PTD_) + r".\end{align}", as_latex=True)
 
                 write_and_save(
-                    "For the salt component, mass transfer is governed by " + eq_type_ + " equations in " + eq.full_particle_conc_domain(column_model.resolution, par_type.resolution, par_type.has_core, with_par_index=False, with_time_domain=True) + tmp_str)
+                    "For the salt component, mass transfer is governed by " + eq_type_ + " equations in " + eq.full_particle_conc_domain(column_model.resolution, par_type.resolution, par_type.has_core, with_par_index=False, with_time_domain=True, column_type=column_model.column_type) + tmp_str)
 
                 # The salt component is in rapid equilibrium binding mode
                 tmpReqBnd = column_model.req_binding

--- a/Equation-Generator.py
+++ b/Equation-Generator.py
@@ -185,6 +185,10 @@ st.markdown(html, unsafe_allow_html=True)
 
 if column_model.resolution == "0D":
     intro_str = r"Consider a continuously stirred tank "
+elif column_model.column_type == "Radial":
+    intro_str = r"Consider a hollow cylindrical column with inner radius $R^{\mathrm{in}} > 0$ and outer radius $R^{\mathrm{out}} > R^{\mathrm{in}}$ "
+elif column_model.column_type == "Frustum":
+    intro_str = r"Consider a conical frustum column of length $L > 0$ with inlet radius $R^0 > 0$ and outlet radius $R^L > 0$ "
 else:
     intro_str = r"Consider a cylindrical column of length $L > 0$ "
     if column_model.resolution == "2D" or column_model.resolution == "3D":

--- a/src/equations.py
+++ b/src/equations.py
@@ -73,21 +73,29 @@ def int_vol_0DContinuum_asmpt(N_p: int, nonlimiting_filmDiff: bool):
     return [r"the tank is spatially homogeneous (i.e., the spatial position inside the " + volume_string + " does not matter);"]
 
 
-def int_vol_continuum_asmpt(resolution: str, N_p: int, nonlimiting_filmDiff: bool):
+def int_vol_continuum_asmpt(resolution: str, N_p: int, nonlimiting_filmDiff: bool, column_type: str = "Axial"):
 
     asmpts = []
-    if int(re.search(r'\d?', resolution).group()) > 0:
+
+    if column_type == "Radial" and resolution != "0D":
+        asmpts.append(
+            r"the fluid only flows in the radial direction of the column (i.e., there is no flow in the axial and angular direction);")
+        asmpts.append(
+            r"the column is a hollow cylinder with inner radius $R^{\mathrm{in}}$ and outer radius $R^{\mathrm{out}}$;")
+    elif column_type == "Frustum" and resolution != "0D":
         asmpts.append(
             r"the fluid only flows in the axial direction of the column (i.e., there is no flow in the radial and angular direction);")
+        asmpts.append(
+            r"the column has a conical frustum shape with linearly varying radius $r(z) = r_0 + \frac{z}{L}(r_L - r_0)$;")
 
     if resolution == "3D":
-        return int_vol_3DContinuum_asmpt(N_p, nonlimiting_filmDiff)
+        return asmpts + int_vol_3DContinuum_asmpt(N_p, nonlimiting_filmDiff)
     elif resolution == "2D":
-        return int_vol_2DContinuum_asmpt(N_p, nonlimiting_filmDiff)
+        return asmpts + int_vol_2DContinuum_asmpt(N_p, nonlimiting_filmDiff)
     elif resolution == "1D":
-        return int_vol_1DContinuum_asmpt(N_p, nonlimiting_filmDiff)
+        return asmpts + int_vol_1DContinuum_asmpt(N_p, nonlimiting_filmDiff)
     elif resolution == "0D":
-        return int_vol_0DContinuum_asmpt(N_p, nonlimiting_filmDiff)
+        return asmpts + int_vol_0DContinuum_asmpt(N_p, nonlimiting_filmDiff)
 
 
 def particle_asmpts():
@@ -258,6 +266,32 @@ def angular_dispersion(eps:str=None):
         return r"\frac{1}{\rho} \frac{\partial}{\partial \varphi} \left( " + eps + r" D^{\mathrm{ang}}_{i}  \frac{\partial c^{\b}_i}{\partial \varphi} \right)"
 
 
+# Radial flow column transport terms (primary transport in radial direction)
+def radial_flow_convection(eps:str=None):
+    if eps is None:
+        return r"- \frac{u}{\rho} \frac{\partial c^{\b}_i}{\partial \rho}"
+    else:
+        return r"- \frac{u}{\rho} \frac{\partial \left( " + eps + r" c^{\b}_i \right)}{\partial \rho}"
+def radial_flow_dispersion(eps:str=None):
+    if eps is None:
+        return r"\frac{1}{\rho} \frac{\partial}{\partial \rho} \left( \rho D^{\mathrm{ax}}_{i} \frac{\partial c^{\b}_i}{\partial \rho} \right)"
+    else:
+        return r"\frac{1}{\rho} \frac{\partial}{\partial \rho} \left( \rho " + eps + r" D^{\mathrm{ax}}_{i} \frac{\partial c^{\b}_i}{\partial \rho} \right)"
+
+
+# Frustum (conical) column transport terms (axial transport with varying cross-section)
+def frustum_convection(eps:str=None):
+    if eps is None:
+        return r"- \frac{u}{r(z)^2} \frac{\partial c^{\b}_i}{\partial z}"
+    else:
+        return r"- \frac{u}{r(z)^2} \frac{\partial \left( " + eps + r" c^{\b}_i \right)}{\partial z}"
+def frustum_dispersion(eps:str=None):
+    if eps is None:
+        return r"\frac{1}{r(z)^2} \frac{\partial}{\partial z} \left( r(z)^2 D^{\mathrm{ax}}_{i} \frac{\partial c^{\b}_i}{\partial z} \right)"
+    else:
+        return r"\frac{1}{r(z)^2} \frac{\partial}{\partial z} \left( r(z)^2 " + eps + r" D^{\mathrm{ax}}_{i} \frac{\partial c^{\b}_i}{\partial z} \right)"
+
+
 # Film diffusion in the interstitial volume
 def int_filmDiff_term(particle, numIdxBegin, numIdxEnd, singleParticle:bool, nonLimitingFilmDiff:bool, hasSurfDiff:bool):
 
@@ -355,7 +389,7 @@ def conserved_moiety_equation_particle_solid(singleParticle: bool):
 # Boundary conditions of the interstitial volume equations
 
 
-def int_vol_BC(resolution: str, hasAxialDispersion: bool):
+def int_vol_BC(resolution: str, hasAxialDispersion: bool, column_type: str = "Axial"):
 
     # handle domain the BC is defined on
     ax_bc_domain = r"(0, T^{\mathrm{end}})"
@@ -371,32 +405,57 @@ def int_vol_BC(resolution: str, hasAxialDispersion: bool):
         rad_bc_domain = r"(0, T^{\mathrm{end}}) \times (0, L) \times [0,2\pi)"
         ang_bc_domain = r"(0, T^{\mathrm{end}}) \times (0, L) \times (0, R^{\mathrm{c}})"
 
-    # define single equations
-    ax_diff_term = r"- D^{\mathrm{ax}}_{i} \frac{\partial c^{\b}_i}{\partial z}" if hasAxialDispersion else ""
-    inflow_bc = r"u c_{\mathrm{in},i} &= \left.\left( u c^{\b}_i " + \
-        ax_diff_term + \
-        r"\right)\right|_{z=0} & &\qquad\text{on }" + ax_bc_domain
-    outflow_bc = r"0 &= - D^{\mathrm{ax}}_{i} \left. \frac{\partial c^{\b}_i}{\partial z} \right|_{z=L} & &\qquad\text{on }" + ax_bc_domain
+    if column_type == "Radial":
+        # Radial flow: transport in rho direction, domain (R_in, R_out)
+        radflow_bc_domain = r"(0, T^{\mathrm{end}})"
+        diff_term = r"- D^{\mathrm{ax}}_{i} \frac{\partial c^{\b}_i}{\partial \rho}" if hasAxialDispersion else ""
+        inflow_bc = r"u c_{\mathrm{in},i} &= \left.\left( u c^{\b}_i " + \
+            diff_term + \
+            r"\right)\right|_{\rho=R^{\mathrm{in}}} & &\qquad\text{on }" + radflow_bc_domain
+        outflow_bc = r"0 &= - D^{\mathrm{ax}}_{i} \left. \frac{\partial c^{\b}_i}{\partial \rho} \right|_{\rho=R^{\mathrm{out}}} & &\qquad\text{on }" + radflow_bc_domain
 
-    rad_wall_bc = r"0 &= - \left(D^{\mathrm{rad}}_{i} \left. \frac{\partial c^{\b}_i}{\partial \rho} \right) \right|_{\rho=R^{\mathrm{c}}} & &\qquad\text{on }" + rad_bc_domain
-    rad_inner_bc = r"0 &= - \left(D^{\mathrm{rad}}_{i} \left. \frac{\partial c^{\b}_i}{\partial \rho} \right) \right|_{\rho=0} & &\qquad\text{on }" + rad_bc_domain
-
-    ang_periodic_bc = r"0 &= D^{\mathrm{ang}}_{i} \, c^{\b}_i \Big|_{\varphi=0} - D^{\mathrm{ang}}_{i} \, c^{\b}_i \Big|_{\varphi=2\pi} & &\quad \text{on }" + ang_bc_domain
-
-    # collect the required equations for full BC
-    boundary_conditions = inflow_bc
-
-    if hasAxialDispersion:
-        boundary_conditions += r""",\\
+        boundary_conditions = inflow_bc
+        if hasAxialDispersion:
+            boundary_conditions += r""",\\
                """ + outflow_bc
 
-    if resolution in ["2D", "3D"]:
-        boundary_conditions += r""",\\
+    elif column_type == "Frustum":
+        # Frustum: transport in z direction with varying cross-section
+        diff_term = r"- D^{\mathrm{ax}}_{i} \frac{\partial c^{\b}_i}{\partial z}" if hasAxialDispersion else ""
+        inflow_bc = r"\frac{u}{r(z)^2} c_{\mathrm{in},i} &= \left.\left( \frac{u}{r(z)^2} c^{\b}_i " + \
+            diff_term + \
+            r"\right)\right|_{z=0} & &\qquad\text{on }" + ax_bc_domain
+        outflow_bc = r"0 &= - D^{\mathrm{ax}}_{i} \left. \frac{\partial c^{\b}_i}{\partial z} \right|_{z=L} & &\qquad\text{on }" + ax_bc_domain
+
+        boundary_conditions = inflow_bc
+        if hasAxialDispersion:
+            boundary_conditions += r""",\\
+               """ + outflow_bc
+
+    else:
+        # Axial (default): standard cylindrical column
+        ax_diff_term = r"- D^{\mathrm{ax}}_{i} \frac{\partial c^{\b}_i}{\partial z}" if hasAxialDispersion else ""
+        inflow_bc = r"u c_{\mathrm{in},i} &= \left.\left( u c^{\b}_i " + \
+            ax_diff_term + \
+            r"\right)\right|_{z=0} & &\qquad\text{on }" + ax_bc_domain
+        outflow_bc = r"0 &= - D^{\mathrm{ax}}_{i} \left. \frac{\partial c^{\b}_i}{\partial z} \right|_{z=L} & &\qquad\text{on }" + ax_bc_domain
+
+        boundary_conditions = inflow_bc
+
+        if hasAxialDispersion:
+            boundary_conditions += r""",\\
+               """ + outflow_bc
+
+        if resolution in ["2D", "3D"]:
+            rad_wall_bc = r"0 &= - \left(D^{\mathrm{rad}}_{i} \left. \frac{\partial c^{\b}_i}{\partial \rho} \right) \right|_{\rho=R^{\mathrm{c}}} & &\qquad\text{on }" + rad_bc_domain
+            rad_inner_bc = r"0 &= - \left(D^{\mathrm{rad}}_{i} \left. \frac{\partial c^{\b}_i}{\partial \rho} \right) \right|_{\rho=0} & &\qquad\text{on }" + rad_bc_domain
+            boundary_conditions += r""",\\
 """ + rad_wall_bc + r""",\\
 """ + rad_inner_bc
 
-    if resolution == "3D":
-        boundary_conditions += r""",\\
+        if resolution == "3D":
+            ang_periodic_bc = r"0 &= D^{\mathrm{ang}}_{i} \, c^{\b}_i \Big|_{\varphi=0} - D^{\mathrm{ang}}_{i} \, c^{\b}_i \Big|_{\varphi=2\pi} & &\quad \text{on }" + ang_bc_domain
+            boundary_conditions += r""",\\
 """ + ang_periodic_bc
 
     return r"""
@@ -437,12 +496,15 @@ def int_vol_initial(resolution: str, includeParLiquid: bool):
     return equation
 
 
-def int_vol_domain(resolution:str, with_time_domain=True):
+def int_vol_domain(resolution:str, with_time_domain=True, column_type:str="Axial"):
 
     domain_ = r"(0, T^\mathrm{end})" if with_time_domain else ""
 
     if int(re.search("\\d", resolution).group()) > 0:
-        domain_ += r"\times (0, L)" if with_time_domain else r"(0, L)"
+        if column_type == "Radial":
+            domain_ += r"\times (R^\mathrm{in}, R^\mathrm{out})" if with_time_domain else r"(R^\mathrm{in}, R^\mathrm{out})"
+        else:
+            domain_ += r"\times (0, L)" if with_time_domain else r"(0, L)"
     if int(re.search("\\d", resolution).group()) > 1:
         domain_ += r"\times (0, R^\mathrm{c})"
     if int(re.search("\\d", resolution).group()) > 2:

--- a/src/equations.py
+++ b/src/equations.py
@@ -86,7 +86,7 @@ def int_vol_continuum_asmpt(resolution: str, N_p: int, nonlimiting_filmDiff: boo
         asmpts.append(
             r"the fluid only flows in the axial direction of the column (i.e., there is no flow in the radial and angular direction);")
         asmpts.append(
-            r"the column has a conical frustum shape with linearly varying radius $r(z) = r_0 + \frac{z}{L}(r_L - r_0)$;")
+            r"the column has a conical frustum shape with linearly varying radius $r(z) = R^0 + \frac{z}{L}(R^L - R^0)$;")
 
     if resolution == "3D":
         return asmpts + int_vol_3DContinuum_asmpt(N_p, nonlimiting_filmDiff)
@@ -269,9 +269,9 @@ def angular_dispersion(eps:str=None):
 # Radial flow column transport terms (primary transport in radial direction)
 def radial_flow_convection(eps:str=None):
     if eps is None:
-        return r"- \frac{u}{\rho} \frac{\partial c^{\b}_i}{\partial \rho}"
+        return r"- \frac{v}{\rho} \frac{\partial c^{\b}_i}{\partial \rho}"
     else:
-        return r"- \frac{u}{\rho} \frac{\partial \left( " + eps + r" c^{\b}_i \right)}{\partial \rho}"
+        return r"- \frac{v}{\rho} \frac{\partial \left( " + eps + r" c^{\b}_i \right)}{\partial \rho}"
 def radial_flow_dispersion(eps:str=None):
     if eps is None:
         return r"\frac{1}{\rho} \frac{\partial}{\partial \rho} \left( \rho D^{\mathrm{ax}}_{i} \frac{\partial c^{\b}_i}{\partial \rho} \right)"
@@ -282,9 +282,9 @@ def radial_flow_dispersion(eps:str=None):
 # Frustum (conical) column transport terms (axial transport with varying cross-section)
 def frustum_convection(eps:str=None):
     if eps is None:
-        return r"- \frac{u}{r(z)^2} \frac{\partial c^{\b}_i}{\partial z}"
+        return r"- \frac{v}{r(z)^2} \frac{\partial c^{\b}_i}{\partial z}"
     else:
-        return r"- \frac{u}{r(z)^2} \frac{\partial \left( " + eps + r" c^{\b}_i \right)}{\partial z}"
+        return r"- \frac{v}{r(z)^2} \frac{\partial \left( " + eps + r" c^{\b}_i \right)}{\partial z}"
 def frustum_dispersion(eps:str=None):
     if eps is None:
         return r"\frac{1}{r(z)^2} \frac{\partial}{\partial z} \left( r(z)^2 D^{\mathrm{ax}}_{i} \frac{\partial c^{\b}_i}{\partial z} \right)"
@@ -409,7 +409,7 @@ def int_vol_BC(resolution: str, hasAxialDispersion: bool, column_type: str = "Ax
         # Radial flow: transport in rho direction, domain (R_in, R_out)
         radflow_bc_domain = r"(0, T^{\mathrm{end}})"
         diff_term = r"- D^{\mathrm{ax}}_{i} \frac{\partial c^{\b}_i}{\partial \rho}" if hasAxialDispersion else ""
-        inflow_bc = r"u c_{\mathrm{in},i} &= \left.\left( u c^{\b}_i " + \
+        inflow_bc = r"v c_{\mathrm{in},i} &= \left.\left( v c^{\b}_i " + \
             diff_term + \
             r"\right)\right|_{\rho=R^{\mathrm{in}}} & &\qquad\text{on }" + radflow_bc_domain
         outflow_bc = r"0 &= - D^{\mathrm{ax}}_{i} \left. \frac{\partial c^{\b}_i}{\partial \rho} \right|_{\rho=R^{\mathrm{out}}} & &\qquad\text{on }" + radflow_bc_domain
@@ -422,7 +422,7 @@ def int_vol_BC(resolution: str, hasAxialDispersion: bool, column_type: str = "Ax
     elif column_type == "Frustum":
         # Frustum: transport in z direction with varying cross-section
         diff_term = r"- D^{\mathrm{ax}}_{i} \frac{\partial c^{\b}_i}{\partial z}" if hasAxialDispersion else ""
-        inflow_bc = r"\frac{u}{r(z)^2} c_{\mathrm{in},i} &= \left.\left( \frac{u}{r(z)^2} c^{\b}_i " + \
+        inflow_bc = r"\frac{v}{r(z)^2} c_{\mathrm{in},i} &= \left.\left( \frac{v}{r(z)^2} c^{\b}_i " + \
             diff_term + \
             r"\right)\right|_{z=0} & &\qquad\text{on }" + ax_bc_domain
         outflow_bc = r"0 &= - D^{\mathrm{ax}}_{i} \left. \frac{\partial c^{\b}_i}{\partial z} \right|_{z=L} & &\qquad\text{on }" + ax_bc_domain

--- a/src/equations.py
+++ b/src/equations.py
@@ -86,7 +86,7 @@ def int_vol_continuum_asmpt(resolution: str, N_p: int, nonlimiting_filmDiff: boo
         asmpts.append(
             r"the fluid only flows in the axial direction of the column (i.e., there is no flow in the radial and angular direction);")
         asmpts.append(
-            r"the column has a conical frustum shape where $r(x) = R^0 + \frac{R^L - R^0}{L} x$ is the column radius function;")
+            r"the column has a conical frustum shape with linearly varying radius;")
 
     if resolution == "3D":
         return asmpts + int_vol_3DContinuum_asmpt(N_p, nonlimiting_filmDiff)

--- a/src/equations.py
+++ b/src/equations.py
@@ -86,7 +86,7 @@ def int_vol_continuum_asmpt(resolution: str, N_p: int, nonlimiting_filmDiff: boo
         asmpts.append(
             r"the fluid only flows in the axial direction of the column (i.e., there is no flow in the radial and angular direction);")
         asmpts.append(
-            r"the column has a conical frustum shape with linearly varying radius $r(z) = R^0 + \frac{z}{L}(R^L - R^0)$;")
+            r"the column has a conical frustum shape with linearly varying radius;")
 
     if resolution == "3D":
         return asmpts + int_vol_3DContinuum_asmpt(N_p, nonlimiting_filmDiff)
@@ -282,14 +282,14 @@ def radial_flow_dispersion(eps:str=None):
 # Frustum (conical) column transport terms (axial transport with varying cross-section)
 def frustum_convection(eps:str=None):
     if eps is None:
-        return r"- \frac{v}{r(z)^2} \frac{\partial c^{\b}_i}{\partial z}"
+        return r"- \frac{v}{r(x)^2} \frac{\partial c^{\b}_i}{\partial x}"
     else:
-        return r"- \frac{v}{r(z)^2} \frac{\partial \left( " + eps + r" c^{\b}_i \right)}{\partial z}"
+        return r"- \frac{v}{r(x)^2} \frac{\partial \left( " + eps + r" c^{\b}_i \right)}{\partial x}"
 def frustum_dispersion(eps:str=None):
     if eps is None:
-        return r"\frac{1}{r(z)^2} \frac{\partial}{\partial z} \left( r(z)^2 D^{\mathrm{ax}}_{i} \frac{\partial c^{\b}_i}{\partial z} \right)"
+        return r"\frac{1}{r(x)^2} \frac{\partial}{\partial x} \left( r(x)^2 D^{\mathrm{ax}}_{i} \frac{\partial c^{\b}_i}{\partial x} \right)"
     else:
-        return r"\frac{1}{r(z)^2} \frac{\partial}{\partial z} \left( r(z)^2 " + eps + r" D^{\mathrm{ax}}_{i} \frac{\partial c^{\b}_i}{\partial z} \right)"
+        return r"\frac{1}{r(x)^2} \frac{\partial}{\partial x} \left( r(x)^2 " + eps + r" D^{\mathrm{ax}}_{i} \frac{\partial c^{\b}_i}{\partial x} \right)"
 
 
 # Film diffusion in the interstitial volume
@@ -420,12 +420,12 @@ def int_vol_BC(resolution: str, hasAxialDispersion: bool, column_type: str = "Ax
                """ + outflow_bc
 
     elif column_type == "Frustum":
-        # Frustum: transport in z direction with varying cross-section
-        diff_term = r"- D^{\mathrm{ax}}_{i} \frac{\partial c^{\b}_i}{\partial z}" if hasAxialDispersion else ""
-        inflow_bc = r"\frac{v}{r(z)^2} c_{\mathrm{in},i} &= \left.\left( \frac{v}{r(z)^2} c^{\b}_i " + \
+        # Frustum: transport in x direction with varying cross-section
+        diff_term = r"- D^{\mathrm{ax}}_{i} \frac{\partial c^{\b}_i}{\partial x}" if hasAxialDispersion else ""
+        inflow_bc = r"\frac{v}{r(x)^2} c_{\mathrm{in},i} &= \left.\left( \frac{v}{r(x)^2} c^{\b}_i " + \
             diff_term + \
-            r"\right)\right|_{z=0} & &\qquad\text{on }" + ax_bc_domain
-        outflow_bc = r"0 &= - D^{\mathrm{ax}}_{i} \left. \frac{\partial c^{\b}_i}{\partial z} \right|_{z=L} & &\qquad\text{on }" + ax_bc_domain
+            r"\right)\right|_{x=0} & &\qquad\text{on }" + ax_bc_domain
+        outflow_bc = r"0 &= - D^{\mathrm{ax}}_{i} \left. \frac{\partial c^{\b}_i}{\partial x} \right|_{x=L} & &\qquad\text{on }" + ax_bc_domain
 
         boundary_conditions = inflow_bc
         if hasAxialDispersion:

--- a/src/equations.py
+++ b/src/equations.py
@@ -817,10 +817,14 @@ def particle_domain(particle_resolution: str, hasCore: bool, with_par_index=Fals
     return par1D_domain
 
 
-def full_particle_conc_domain(column_resolution: str, particle_resolution: str, hasCore: bool, with_par_index=False, with_time_domain=True):
-    
+def full_particle_conc_domain(column_resolution: str, particle_resolution: str, hasCore: bool, with_par_index=False, with_time_domain=True, column_type: str="Axial"):
+
     if not column_resolution == "0D":
-        domain = r"$(0, T^\mathrm{end}) \times (0, L)" if with_time_domain else r"$\times (0, L)"
+        if column_type == "Radial":
+            spatial = r"(R^\mathrm{in}, R^\mathrm{out})"
+        else:
+            spatial = r"(0, L)"
+        domain = r"$(0, T^\mathrm{end}) \times " + spatial if with_time_domain else r"$\times " + spatial
     else:
         domain = r"$(0, T^\mathrm{end})" if with_time_domain else r"$"
     

--- a/src/equations.py
+++ b/src/equations.py
@@ -86,7 +86,7 @@ def int_vol_continuum_asmpt(resolution: str, N_p: int, nonlimiting_filmDiff: boo
         asmpts.append(
             r"the fluid only flows in the axial direction of the column (i.e., there is no flow in the radial and angular direction);")
         asmpts.append(
-            r"the column has a conical frustum shape with linearly varying radius;")
+            r"the column has a conical frustum shape where $r(x) = R^0 + \frac{R^L - R^0}{L} x$ is the column radius function;")
 
     if resolution == "3D":
         return asmpts + int_vol_3DContinuum_asmpt(N_p, nonlimiting_filmDiff)

--- a/src/equations.py
+++ b/src/equations.py
@@ -274,9 +274,9 @@ def radial_flow_convection(eps:str=None):
         return r"- \frac{v}{\rho} \frac{\partial \left( " + eps + r" c^{\b}_i \right)}{\partial \rho}"
 def radial_flow_dispersion(eps:str=None):
     if eps is None:
-        return r"\frac{1}{\rho} \frac{\partial}{\partial \rho} \left( \rho D^{\mathrm{ax}}_{i} \frac{\partial c^{\b}_i}{\partial \rho} \right)"
+        return r"\frac{1}{\rho} \frac{\partial}{\partial \rho} \left( \rho D^{\mathrm{rad}}_{i} \frac{\partial c^{\b}_i}{\partial \rho} \right)"
     else:
-        return r"\frac{1}{\rho} \frac{\partial}{\partial \rho} \left( \rho " + eps + r" D^{\mathrm{ax}}_{i} \frac{\partial c^{\b}_i}{\partial \rho} \right)"
+        return r"\frac{1}{\rho} \frac{\partial}{\partial \rho} \left( \rho " + eps + r" D^{\mathrm{rad}}_{i} \frac{\partial c^{\b}_i}{\partial \rho} \right)"
 
 
 # Frustum (conical) column transport terms (axial transport with varying cross-section)
@@ -408,11 +408,11 @@ def int_vol_BC(resolution: str, hasAxialDispersion: bool, column_type: str = "Ax
     if column_type == "Radial":
         # Radial flow: transport in rho direction, domain (R_in, R_out)
         radflow_bc_domain = r"(0, T^{\mathrm{end}})"
-        diff_term = r"- D^{\mathrm{ax}}_{i} \frac{\partial c^{\b}_i}{\partial \rho}" if hasAxialDispersion else ""
+        diff_term = r"- D^{\mathrm{rad}}_{i} \frac{\partial c^{\b}_i}{\partial \rho}" if hasAxialDispersion else ""
         inflow_bc = r"v c_{\mathrm{in},i} &= \left.\left( v c^{\b}_i " + \
             diff_term + \
             r"\right)\right|_{\rho=R^{\mathrm{in}}} & &\qquad\text{on }" + radflow_bc_domain
-        outflow_bc = r"0 &= - D^{\mathrm{ax}}_{i} \left. \frac{\partial c^{\b}_i}{\partial \rho} \right|_{\rho=R^{\mathrm{out}}} & &\qquad\text{on }" + radflow_bc_domain
+        outflow_bc = r"0 &= - D^{\mathrm{rad}}_{i} \left. \frac{\partial c^{\b}_i}{\partial \rho} \right|_{\rho=R^{\mathrm{out}}} & &\qquad\text{on }" + radflow_bc_domain
 
         boundary_conditions = inflow_bc
         if hasAxialDispersion:

--- a/src/model_column.py
+++ b/src/model_column.py
@@ -123,8 +123,9 @@ class Column:
 
         if self.has_axial_coordinate:
             with col2:
+                dispersion_label = "Add radial Dispersion" if self.column_type == "Radial" else "Add axial Dispersion"
                 self.has_axial_dispersion = st.sidebar.selectbox(
-                    "Add axial Dispersion", ["No", "Yes"], key=r"has_axial_dispersion") == "Yes"
+                    dispersion_label, ["No", "Yes"], key=r"has_axial_dispersion") == "Yes"
 
         if self.dev_mode:
             if self.has_radial_coordinate:
@@ -419,10 +420,20 @@ class Column:
             ]
 
         if self.has_axial_dispersion:
-            if not without_pores_:
-                self.vars_and_params.append({"Group" : 6, "Symbol": r"D^\mathrm{ax}_i", "Description": r"axial dispersion coefficient", "Unit": r"\frac{m^2}{s}", "Dependence": param_deps_comp, "Property": r"\geq 0"})
+            if self.column_type == "Radial":
+                disp_symbol = r"D^\mathrm{rad}_i"
+                disp_desc = r"radial dispersion coefficient"
+                disp_symbol_apparent = r"\tilde{D}^\mathrm{rad}_i"
+                disp_desc_apparent = r"apparent radial dispersion coefficient"
             else:
-                self.vars_and_params.append({"Group" : 6, "Symbol": r"\tilde{D}^\mathrm{ax}_i", "Description": r"apparent axial dispersion coefficient", "Unit": r"\frac{m^2}{s}", "Dependence": param_deps_comp, "Property": r"\geq 0"})
+                disp_symbol = r"D^\mathrm{ax}_i"
+                disp_desc = r"axial dispersion coefficient"
+                disp_symbol_apparent = r"\tilde{D}^\mathrm{ax}_i"
+                disp_desc_apparent = r"apparent axial dispersion coefficient"
+            if not without_pores_:
+                self.vars_and_params.append({"Group" : 6, "Symbol": disp_symbol, "Description": disp_desc, "Unit": r"\frac{m^2}{s}", "Dependence": param_deps_comp, "Property": r"\geq 0"})
+            else:
+                self.vars_and_params.append({"Group" : 6, "Symbol": disp_symbol_apparent, "Description": disp_desc_apparent, "Unit": r"\frac{m^2}{s}", "Dependence": param_deps_comp, "Property": r"\geq 0"})
         if self.has_radial_dispersion:
             self.vars_and_params.append({"Group" : 6, "Symbol": r"D^\mathrm{rad}_i", "Description": r"radial dispersion coefficient", "Unit": r"\frac{m^2}{s}", "Dependence": param_deps_comp, "Property": r"\geq 0"})
         if self.has_angular_dispersion:

--- a/src/model_column.py
+++ b/src/model_column.py
@@ -458,7 +458,7 @@ class Column:
             self.vars_and_params.append({"Group" : -1, "Symbol": r"L", "Description": r"length of column", "Unit": r"m", "Dependence": r"\text{constant}", "Property": r" > 0"})
             self.vars_and_params.append({"Group" : -1, "Symbol": r"R^0", "Description": r"column radius at inlet", "Unit": r"m", "Dependence": r"\text{constant}", "Property": r" > 0"})
             self.vars_and_params.append({"Group" : -1, "Symbol": r"R^L", "Description": r"column radius at outlet", "Unit": r"m", "Dependence": r"\text{constant}", "Property": r" > 0"})
-            self.vars_and_params.append({"Group" : 3, "Symbol": r"r(x)", "Description": r"column radius function", "Unit": r"m", "Dependence": r"x"})
+            self.vars_and_params.append({"Group" : 3, "Symbol": r"r(x) = R^0 + \frac{R^L - R^0}{L} x", "Description": r"column radius function", "Unit": r"m", "Dependence": r"x"})
             self.vars_and_params.append({"Group" : 2, "Symbol": r"Q", "Description": r"volumetric flow rate", "Unit": r"\frac{m^3}{s}", "Dependence": r"\text{constant}", "Property": r"> 0"})
             self.vars_and_params.append({"Group" : 5, "Symbol": r"v", "Description": r"velocity coefficient", "Unit": r"\frac{m^3}{s}", "Dependence": r"\text{constant}", "Property": r":= \frac{Q}{\pi}"})
         else:

--- a/src/model_column.py
+++ b/src/model_column.py
@@ -458,7 +458,7 @@ class Column:
             self.vars_and_params.append({"Group" : -1, "Symbol": r"L", "Description": r"length of column", "Unit": r"m", "Dependence": r"\text{constant}", "Property": r" > 0"})
             self.vars_and_params.append({"Group" : -1, "Symbol": r"R^0", "Description": r"column radius at inlet", "Unit": r"m", "Dependence": r"\text{constant}", "Property": r" > 0"})
             self.vars_and_params.append({"Group" : -1, "Symbol": r"R^L", "Description": r"column radius at outlet", "Unit": r"m", "Dependence": r"\text{constant}", "Property": r" > 0"})
-            self.vars_and_params.append({"Group" : 3, "Symbol": r"r(x)", "Description": r"column radius function, $r(x) = R^0 + \frac{R^L - R^0}{L} x$", "Unit": r"m", "Dependence": r"x"})
+            self.vars_and_params.append({"Group" : 3, "Symbol": r"r(x)", "Description": r"column radius function", "Unit": r"m", "Dependence": r"x"})
             self.vars_and_params.append({"Group" : 2, "Symbol": r"Q", "Description": r"volumetric flow rate", "Unit": r"\frac{m^3}{s}", "Dependence": r"\text{constant}", "Property": r"> 0"})
             self.vars_and_params.append({"Group" : 5, "Symbol": r"v", "Description": r"velocity coefficient", "Unit": r"\frac{m^3}{s}", "Dependence": r"\text{constant}", "Property": r":= \frac{Q}{\pi}"})
         else:

--- a/src/model_column.py
+++ b/src/model_column.py
@@ -82,8 +82,17 @@ class Column:
         col1, col2 = st.columns(2)
 
         with col1:
-            self.resolution = re.search(r'\dD', st.sidebar.selectbox("Column resolution", [
-                                        "1D (axial coordinate)", "0D (Homogeneous Tank)", "2D (axial and radial coordinate)", "3D (axial, radial and angular coordinate)"], key=r"column_resolution")).group()
+            column_type_label = st.sidebar.selectbox("Column geometry", [
+                "Axial flow cylinder", "Radial flow cylinder", "Frustum"], key=r"column_type")
+            self.column_type = {"Axial flow cylinder": "Axial", "Radial flow cylinder": "Radial", "Frustum": "Frustum"}[column_type_label]
+
+            resolution_options = {
+                "Axial": ["1D (axial coordinate)", "0D (Homogeneous Tank)", "2D (axial and radial coordinate)", "3D (axial, radial and angular coordinate)"],
+                "Radial": ["1D (radial coordinate)"],
+                "Frustum": ["1D (axial coordinate)"],
+            }
+            self.resolution = re.search(r'\dD', st.sidebar.selectbox("Column resolution",
+                                        resolution_options[self.column_type], key=r"column_resolution")).group()
 
         valid_resolutions = {"3D", "2D", "1D", "0D"}
 
@@ -93,9 +102,6 @@ class Column:
         if int(re.search("\\d", self.resolution).group()) == 0:
             self.has_filter = st.sidebar.selectbox(
                     "Add flow rate filter", ["No", "Yes"], key=r"has_filter") == "Yes"
-        if int(re.search("\\d", self.resolution).group()) > 0:
-            column_type_options = ["Axial", "Radial", "Frustum"] if self.resolution == "1D" else ["Axial"]
-            self.column_type = st.sidebar.selectbox("Column geometry", column_type_options, key=r"column_type")
         if int(re.search("\\d", self.resolution).group()) > 0:
             self.has_axial_coordinate = True
             self.has_axial_dispersion = True
@@ -320,9 +326,6 @@ class Column:
         if self.has_angular_coordinate:
             return -1
 
-        if self.column_type in ["Radial", "Frustum"]:
-            return -1
-
         availability = 1
 
         par1D = None
@@ -376,10 +379,13 @@ class Column:
         
         if self.N_p > 1:
             return -1
-        
+
         if self.has_radial_coordinate:
             return -1
-        
+
+        if self.column_type in ["Radial", "Frustum"]:
+            return -1
+
         else:
             return core_availability
 
@@ -431,20 +437,14 @@ class Column:
             self.vars_and_params.append({"Group" : 0, "Symbol": r"\rho", "Description": r"radial coordinate", "Unit": r"m", "Dependence": r"\text{independent variable}", "Property": r"\in (R^{\mathrm{in}}, R^{\mathrm{out}})"})
             self.vars_and_params.append({"Group" : -1, "Symbol": r"R^{\mathrm{in}}", "Description": r"inner cylinder radius", "Unit": r"m", "Dependence": r"\text{constant}", "Property": r" > 0"})
             self.vars_and_params.append({"Group" : -1, "Symbol": r"R^{\mathrm{out}}", "Description": r"outer cylinder radius", "Unit": r"m", "Dependence": r"\text{constant}", "Property": r" > R^{\mathrm{in}}"})
-            if not without_pores_:
-                self.vars_and_params.append({"Group" : 5, "Symbol": r"u", "Description": r"interstitial velocity", "Unit": r"\frac{m}{s}", "Dependence": param_deps, "Property": r"> 0"})
-            else:
-                self.vars_and_params.append({"Group" : 5, "Symbol": r"\tilde{u}", "Description": r"apparent interstitial velocity", "Unit": r"\frac{m}{s}", "Dependence": param_deps, "Property": r"> 0"})
+            self.vars_and_params.append({"Group" : 5, "Symbol": r"v", "Description": r"velocity coefficient, $v = \frac{Q}{2 \pi L}$", "Unit": r"\frac{m^2}{s}", "Dependence": r"\text{constant}", "Property": r"> 0"})
         elif self.column_type == "Frustum":
             self.vars_and_params.append({"Group" : 0, "Symbol": r"z", "Description": r"axial coordinate", "Unit": r"m", "Dependence": r"\text{independent variable}", "Property": r"\in (0, L)"})
             self.vars_and_params.append({"Group" : -1, "Symbol": r"L", "Description": r"length of column", "Unit": r"m", "Dependence": r"\text{constant}", "Property": r" > 0"})
-            self.vars_and_params.append({"Group" : -1, "Symbol": r"r_0", "Description": r"column radius at inlet", "Unit": r"m", "Dependence": r"\text{constant}", "Property": r" > 0"})
-            self.vars_and_params.append({"Group" : -1, "Symbol": r"r_L", "Description": r"column radius at outlet", "Unit": r"m", "Dependence": r"\text{constant}", "Property": r" > 0"})
-            self.vars_and_params.append({"Group" : 3, "Symbol": r"r(z)", "Description": r"column radius function, $r(z) = r_0 + \frac{z}{L}(r_L - r_0)$", "Unit": r"m", "Dependence": r"z"})
-            if not without_pores_:
-                self.vars_and_params.append({"Group" : 5, "Symbol": r"u", "Description": r"interstitial velocity", "Unit": r"\frac{m}{s}", "Dependence": param_deps, "Property": r"> 0"})
-            else:
-                self.vars_and_params.append({"Group" : 5, "Symbol": r"\tilde{u}", "Description": r"apparent interstitial velocity", "Unit": r"\frac{m}{s}", "Dependence": param_deps, "Property": r"> 0"})
+            self.vars_and_params.append({"Group" : -1, "Symbol": r"R^0", "Description": r"column radius at inlet", "Unit": r"m", "Dependence": r"\text{constant}", "Property": r" > 0"})
+            self.vars_and_params.append({"Group" : -1, "Symbol": r"R^L", "Description": r"column radius at outlet", "Unit": r"m", "Dependence": r"\text{constant}", "Property": r" > 0"})
+            self.vars_and_params.append({"Group" : 3, "Symbol": r"r(z)", "Description": r"column radius function, $r(z) = R^0 + \frac{z}{L}(R^L - R^0)$", "Unit": r"m", "Dependence": r"z"})
+            self.vars_and_params.append({"Group" : 5, "Symbol": r"v", "Description": r"velocity coefficient, $v = \frac{Q}{\pi}$", "Unit": r"\frac{m^3}{s}", "Dependence": r"\text{constant}", "Property": r"> 0"})
         else:
             self.vars_and_params.append({"Group" : 0, "Symbol": r"z", "Description": r"axial cylinder coordinate", "Unit": r"m", "Dependence": r"\text{independent variable}", "Property": r"\in (0, L)"})
             self.vars_and_params.append({"Group" : -1, "Symbol": r"L", "Description": r"length of cylinder", "Unit": r"m", "Dependence": r"\text{constant}", "Property": r" > 0"})
@@ -725,12 +725,12 @@ class Column:
             else:
                 model_name = ""
 
-            if self.column_type == "Radial":
-                model_name += "Radial Flow "
-            elif self.column_type == "Frustum":
-                model_name += "Frustum "
-
             if self.N_p > 0:
+
+                if self.column_type == "Radial":
+                    model_name += "Radial Flow "
+                elif self.column_type == "Frustum":
+                    model_name += "Frustum "
 
                 if self.particle_models[0].resolution == "1D":
                     model_name += "General Rate Model"
@@ -747,6 +747,10 @@ class Column:
                         # particle-type distribution # TODO use when different kinds of geometry or binding
                         model_name += " with particle-type distribution"
             else:
+                if self.column_type == "Radial":
+                    model_name += "Radial "
+                elif self.column_type == "Frustum":
+                    model_name += "Frustum "
                 if self.has_axial_dispersion or self.has_radial_dispersion or self.has_angular_dispersion:
                     model_name += "Dispersive "
                 model_name += "Plug Flow"  # Reactor if we have reactions

--- a/src/model_column.py
+++ b/src/model_column.py
@@ -29,6 +29,8 @@ class Column:
     N_c: int = -1
     N_p: int = -1
 
+    column_type: Literal["Axial", "Radial", "Frustum"] = "Axial"
+
     has_axial_coordinate: bool = False
     has_radial_coordinate: bool = False
     has_angular_coordinate: bool = False
@@ -91,6 +93,9 @@ class Column:
         if int(re.search("\\d", self.resolution).group()) == 0:
             self.has_filter = st.sidebar.selectbox(
                     "Add flow rate filter", ["No", "Yes"], key=r"has_filter") == "Yes"
+        if int(re.search("\\d", self.resolution).group()) > 0:
+            column_type_options = ["Axial", "Radial", "Frustum"] if self.resolution == "1D" else ["Axial"]
+            self.column_type = st.sidebar.selectbox("Column geometry", column_type_options, key=r"column_type")
         if int(re.search("\\d", self.resolution).group()) > 0:
             self.has_axial_coordinate = True
             self.has_axial_dispersion = True
@@ -315,6 +320,9 @@ class Column:
         if self.has_angular_coordinate:
             return -1
 
+        if self.column_type in ["Radial", "Frustum"]:
+            return -1
+
         availability = 1
 
         par1D = None
@@ -382,7 +390,10 @@ class Column:
         state_deps = r"t"
         param_deps = r"\text{constant}"
         if self.resolution == "1D":
-            state_deps = r"t, z"
+            if self.column_type == "Radial":
+                state_deps = r"t, \rho"
+            else:
+                state_deps = r"t, z"
         if self.resolution == "2D":
             state_deps = r"t, z, \rho"
             param_deps = r"\rho"
@@ -395,7 +406,7 @@ class Column:
 
         self.vars_and_params = [
             {"Group" : 0, "Symbol": r"t", "Description": r"time coordinate", "Unit": r"s", "Dependence": r"\text{independent variable}", "Property": r"\in (0, T^{\mathrm{end}})"},
-            {"Group" : 1, "Symbol": r"c^{\b}_i", "Description": r"bulk liquid concentration", "Unit": r"\frac{mol}{m^3}", "Dependence" : state_deps, "Domain": eq.int_vol_domain(self.resolution)},
+            {"Group" : 1, "Symbol": r"c^{\b}_i", "Description": r"bulk liquid concentration", "Unit": r"\frac{mol}{m^3}", "Dependence" : state_deps, "Domain": eq.int_vol_domain(self.resolution, column_type=self.column_type)},
             {"Group" : -1, "Symbol": r"T^{\mathrm{end}}", "Description": r"process end time", "Unit": r"s", "Dependence": r"\text{constant}", "Property": r" > 0"},
             {"Group" : -0.2, "Symbol": r"N^\mathrm{c}", "Description": r"number of components", "Unit": r"-", "Dependence": r"-", "Property": r"\in \mathbb{N}"},
             {"Group" : -0.1, "Symbol": r"i", "Description": r"component index", "Unit": r"s", "Dependence": r"-", "Property": r"-"},
@@ -416,6 +427,24 @@ class Column:
             self.vars_and_params.append({"Group" : 2, "Symbol": r"Q^\mathrm{out}", "Description": r"volumetric flow rate out of the tank", "Unit": r"\frac{m^3}{s}", "Dependence": r"\text{constant}", "Property": r"\geq 0"})
             if self.has_filter:
                 self.vars_and_params.append({"Group" : 2, "Symbol": r"Q^\mathrm{filter}", "Description": r"volumetric flow rate out of the tank (solvent only)", "Unit": r"\frac{m^3}{s}", "Dependence": r"\text{constant}", "Property": r"\geq 0"})
+        elif self.column_type == "Radial":
+            self.vars_and_params.append({"Group" : 0, "Symbol": r"\rho", "Description": r"radial coordinate", "Unit": r"m", "Dependence": r"\text{independent variable}", "Property": r"\in (R^{\mathrm{in}}, R^{\mathrm{out}})"})
+            self.vars_and_params.append({"Group" : -1, "Symbol": r"R^{\mathrm{in}}", "Description": r"inner cylinder radius", "Unit": r"m", "Dependence": r"\text{constant}", "Property": r" > 0"})
+            self.vars_and_params.append({"Group" : -1, "Symbol": r"R^{\mathrm{out}}", "Description": r"outer cylinder radius", "Unit": r"m", "Dependence": r"\text{constant}", "Property": r" > R^{\mathrm{in}}"})
+            if not without_pores_:
+                self.vars_and_params.append({"Group" : 5, "Symbol": r"u", "Description": r"interstitial velocity", "Unit": r"\frac{m}{s}", "Dependence": param_deps, "Property": r"> 0"})
+            else:
+                self.vars_and_params.append({"Group" : 5, "Symbol": r"\tilde{u}", "Description": r"apparent interstitial velocity", "Unit": r"\frac{m}{s}", "Dependence": param_deps, "Property": r"> 0"})
+        elif self.column_type == "Frustum":
+            self.vars_and_params.append({"Group" : 0, "Symbol": r"z", "Description": r"axial coordinate", "Unit": r"m", "Dependence": r"\text{independent variable}", "Property": r"\in (0, L)"})
+            self.vars_and_params.append({"Group" : -1, "Symbol": r"L", "Description": r"length of column", "Unit": r"m", "Dependence": r"\text{constant}", "Property": r" > 0"})
+            self.vars_and_params.append({"Group" : -1, "Symbol": r"r_0", "Description": r"column radius at inlet", "Unit": r"m", "Dependence": r"\text{constant}", "Property": r" > 0"})
+            self.vars_and_params.append({"Group" : -1, "Symbol": r"r_L", "Description": r"column radius at outlet", "Unit": r"m", "Dependence": r"\text{constant}", "Property": r" > 0"})
+            self.vars_and_params.append({"Group" : 3, "Symbol": r"r(z)", "Description": r"column radius function, $r(z) = r_0 + \frac{z}{L}(r_L - r_0)$", "Unit": r"m", "Dependence": r"z"})
+            if not without_pores_:
+                self.vars_and_params.append({"Group" : 5, "Symbol": r"u", "Description": r"interstitial velocity", "Unit": r"\frac{m}{s}", "Dependence": param_deps, "Property": r"> 0"})
+            else:
+                self.vars_and_params.append({"Group" : 5, "Symbol": r"\tilde{u}", "Description": r"apparent interstitial velocity", "Unit": r"\frac{m}{s}", "Dependence": param_deps, "Property": r"> 0"})
         else:
             self.vars_and_params.append({"Group" : 0, "Symbol": r"z", "Description": r"axial cylinder coordinate", "Unit": r"m", "Dependence": r"\text{independent variable}", "Property": r"\in (0, L)"})
             self.vars_and_params.append({"Group" : -1, "Symbol": r"L", "Description": r"length of cylinder", "Unit": r"m", "Dependence": r"\text{constant}", "Property": r" > 0"})
@@ -491,10 +520,21 @@ class Column:
             needs_linebreak = self.has_radial_dispersion or self.has_angular_dispersion
             eq_sign = " &= " if needs_linebreak else " = "
 
-            equation += eq_sign + eq.axial_convection() if without_pores_ else eq_sign + eq.axial_convection(r"\varepsilon^{\mathrm{c}}")
+            # Select convection and dispersion terms based on column geometry
+            if self.column_type == "Radial":
+                convection_func = eq.radial_flow_convection
+                dispersion_func = eq.radial_flow_dispersion
+            elif self.column_type == "Frustum":
+                convection_func = eq.frustum_convection
+                dispersion_func = eq.frustum_dispersion
+            else:
+                convection_func = eq.axial_convection
+                dispersion_func = eq.axial_dispersion
+
+            equation += eq_sign + convection_func() if without_pores_ else eq_sign + convection_func(r"\varepsilon^{\mathrm{c}}")
 
             if self.has_axial_dispersion:
-                equation += " + " + eq.axial_dispersion(r"\varepsilon^{\mathrm{c}}")
+                equation += " + " + dispersion_func(r"\varepsilon^{\mathrm{c}}")
             if self.has_radial_dispersion:
                 equation += r" \nonumber \\ & + " + eq.radial_dispersion(r"\varepsilon^{\mathrm{c}}")
             if self.has_angular_dispersion:
@@ -540,7 +580,7 @@ class Column:
 
     def interstitial_volume_bc(self):
         if not self.resolution == "0D":
-            return eq.int_vol_BC(self.resolution, self.has_axial_dispersion)
+            return eq.int_vol_BC(self.resolution, self.has_axial_dispersion, self.column_type)
         else:
             return None
 
@@ -653,7 +693,7 @@ class Column:
             return r"$i \in \{" + ", ".join(str(c) for c in components) + r"\}$"
 
     def domain_interstitial(self, with_time_domain=True):
-        return r"$" + eq.int_vol_domain(self.resolution, with_time_domain=with_time_domain) + r"$"
+        return r"$" + eq.int_vol_domain(self.resolution, with_time_domain=with_time_domain, column_type=self.column_type) + r"$"
 
     def domain_particle(self):
         if self.N_p > 0:
@@ -685,6 +725,11 @@ class Column:
             else:
                 model_name = ""
 
+            if self.column_type == "Radial":
+                model_name += "Radial Flow "
+            elif self.column_type == "Frustum":
+                model_name += "Frustum "
+
             if self.N_p > 0:
 
                 if self.particle_models[0].resolution == "1D":
@@ -715,7 +760,7 @@ class Column:
 
         asmpts = {
             "General model assumptions": eq.HRM_asmpt(self.N_p, self.nonlimiting_filmDiff, self.has_binding, self.has_surfDiff, self.resolution),
-            "Specific model assumptions": eq.int_vol_continuum_asmpt(self.resolution, self.N_p, self.nonlimiting_filmDiff) +
+            "Specific model assumptions": eq.int_vol_continuum_asmpt(self.resolution, self.N_p, self.nonlimiting_filmDiff, self.column_type) +
             (eq.particle_asmpt(
                 self.particle_models[0].resolution, self.has_surfDiff) if self.N_p > 0 else [])
         }

--- a/src/model_column.py
+++ b/src/model_column.py
@@ -400,6 +400,8 @@ class Column:
         if self.resolution == "1D":
             if self.column_type == "Radial":
                 state_deps = r"t, \rho"
+            elif self.column_type == "Frustum":
+                state_deps = r"t, x"
             else:
                 state_deps = r"t, z"
         if self.resolution == "2D":
@@ -449,14 +451,16 @@ class Column:
             self.vars_and_params.append({"Group" : 0, "Symbol": r"\rho", "Description": r"radial coordinate", "Unit": r"m", "Dependence": r"\text{independent variable}", "Property": r"\in (R^{\mathrm{in}}, R^{\mathrm{out}})"})
             self.vars_and_params.append({"Group" : -1, "Symbol": r"R^{\mathrm{in}}", "Description": r"inner cylinder radius", "Unit": r"m", "Dependence": r"\text{constant}", "Property": r" > 0"})
             self.vars_and_params.append({"Group" : -1, "Symbol": r"R^{\mathrm{out}}", "Description": r"outer cylinder radius", "Unit": r"m", "Dependence": r"\text{constant}", "Property": r" > R^{\mathrm{in}}"})
-            self.vars_and_params.append({"Group" : 5, "Symbol": r"v", "Description": r"velocity coefficient, $v = \frac{Q}{2 \pi L}$", "Unit": r"\frac{m^2}{s}", "Dependence": r"\text{constant}", "Property": r"> 0"})
+            self.vars_and_params.append({"Group" : 2, "Symbol": r"Q", "Description": r"volumetric flow rate", "Unit": r"\frac{m^3}{s}", "Dependence": r"\text{constant}", "Property": r"> 0"})
+            self.vars_and_params.append({"Group" : 5, "Symbol": r"v", "Description": r"velocity coefficient", "Unit": r"\frac{m^2}{s}", "Dependence": r"\text{constant}", "Property": r":= \frac{Q}{2 \pi L}"})
         elif self.column_type == "Frustum":
-            self.vars_and_params.append({"Group" : 0, "Symbol": r"z", "Description": r"axial coordinate", "Unit": r"m", "Dependence": r"\text{independent variable}", "Property": r"\in (0, L)"})
+            self.vars_and_params.append({"Group" : 0, "Symbol": r"x", "Description": r"axial coordinate", "Unit": r"m", "Dependence": r"\text{independent variable}", "Property": r"\in (0, L)"})
             self.vars_and_params.append({"Group" : -1, "Symbol": r"L", "Description": r"length of column", "Unit": r"m", "Dependence": r"\text{constant}", "Property": r" > 0"})
             self.vars_and_params.append({"Group" : -1, "Symbol": r"R^0", "Description": r"column radius at inlet", "Unit": r"m", "Dependence": r"\text{constant}", "Property": r" > 0"})
             self.vars_and_params.append({"Group" : -1, "Symbol": r"R^L", "Description": r"column radius at outlet", "Unit": r"m", "Dependence": r"\text{constant}", "Property": r" > 0"})
-            self.vars_and_params.append({"Group" : 3, "Symbol": r"r(z)", "Description": r"column radius function, $r(z) = R^0 + \frac{z}{L}(R^L - R^0)$", "Unit": r"m", "Dependence": r"z"})
-            self.vars_and_params.append({"Group" : 5, "Symbol": r"v", "Description": r"velocity coefficient, $v = \frac{Q}{\pi}$", "Unit": r"\frac{m^3}{s}", "Dependence": r"\text{constant}", "Property": r"> 0"})
+            self.vars_and_params.append({"Group" : 3, "Symbol": r"r(x)", "Description": r"column radius function, $r(x) = R^0 + \frac{R^L - R^0}{L} x$", "Unit": r"m", "Dependence": r"x"})
+            self.vars_and_params.append({"Group" : 2, "Symbol": r"Q", "Description": r"volumetric flow rate", "Unit": r"\frac{m^3}{s}", "Dependence": r"\text{constant}", "Property": r"> 0"})
+            self.vars_and_params.append({"Group" : 5, "Symbol": r"v", "Description": r"velocity coefficient", "Unit": r"\frac{m^3}{s}", "Dependence": r"\text{constant}", "Property": r":= \frac{Q}{\pi}"})
         else:
             self.vars_and_params.append({"Group" : 0, "Symbol": r"z", "Description": r"axial cylinder coordinate", "Unit": r"m", "Dependence": r"\text{independent variable}", "Property": r"\in (0, L)"})
             self.vars_and_params.append({"Group" : -1, "Symbol": r"L", "Description": r"length of cylinder", "Unit": r"m", "Dependence": r"\text{constant}", "Property": r" > 0"})

--- a/src/model_column.py
+++ b/src/model_column.py
@@ -458,7 +458,7 @@ class Column:
             self.vars_and_params.append({"Group" : -1, "Symbol": r"L", "Description": r"length of column", "Unit": r"m", "Dependence": r"\text{constant}", "Property": r" > 0"})
             self.vars_and_params.append({"Group" : -1, "Symbol": r"R^0", "Description": r"column radius at inlet", "Unit": r"m", "Dependence": r"\text{constant}", "Property": r" > 0"})
             self.vars_and_params.append({"Group" : -1, "Symbol": r"R^L", "Description": r"column radius at outlet", "Unit": r"m", "Dependence": r"\text{constant}", "Property": r" > 0"})
-            self.vars_and_params.append({"Group" : 3, "Symbol": r"r(x) = R^0 + \frac{R^L - R^0}{L} x", "Description": r"column radius function", "Unit": r"m", "Dependence": r"x"})
+            self.vars_and_params.append({"Group" : 3, "Symbol": r"R", "Description": r"column radius function", "Unit": r"m", "Dependence": r"x", "Property": r"(x) = R^0 + \frac{R^L - R^0}{L} x"})
             self.vars_and_params.append({"Group" : 2, "Symbol": r"Q", "Description": r"volumetric flow rate", "Unit": r"\frac{m^3}{s}", "Dependence": r"\text{constant}", "Property": r"> 0"})
             self.vars_and_params.append({"Group" : 5, "Symbol": r"v", "Description": r"velocity coefficient", "Unit": r"\frac{m^3}{s}", "Dependence": r"\text{constant}", "Property": r":= \frac{Q}{\pi}"})
         else:

--- a/src/model_column.py
+++ b/src/model_column.py
@@ -250,6 +250,7 @@ class Column:
                         has_surfDiff=self.has_surfDiff,
                         nonlimiting_filmDiff=self.nonlimiting_filmDiff,
                         interstitial_volume_resolution=self.resolution,
+                        column_type=self.column_type,
                         single_partype=(self.N_p == 1),
                         PTD=self.PTD,
                         binding_model=self.binding_model,
@@ -708,7 +709,7 @@ class Column:
 
     def domain_particle(self):
         if self.N_p > 0:
-            return eq.full_particle_conc_domain(self.resolution, self.particle_models[0].resolution, self.particle_models[0].has_core, False, False)
+            return eq.full_particle_conc_domain(self.resolution, self.particle_models[0].resolution, self.particle_models[0].has_core, False, False, column_type=self.column_type)
         else:
             return ""
         

--- a/src/model_particle.py
+++ b/src/model_particle.py
@@ -33,6 +33,7 @@ class Particle:
     nonlimiting_filmDiff: bool = None
     surface_volume_ratio: float = None
     interstitial_volume_resolution: str = None
+    column_type: str = "Axial"
     single_partype: bool = True
     PTD: bool = False
     binding_model: str = "Arbitrary"
@@ -66,7 +67,7 @@ class Particle:
         
         state_deps = r"t"
         if self.interstitial_volume_resolution == "1D":
-            state_deps = r"t, z"
+            state_deps = r"t, \rho" if self.column_type == "Radial" else r"t, z"
         if self.interstitial_volume_resolution == "2D":
             state_deps = r"t, z, \rho"
         if self.interstitial_volume_resolution == "3D":
@@ -78,7 +79,7 @@ class Particle:
 
         if not (self.nonlimiting_filmDiff and self.resolution == "0D"):
             symbol_name_ = r"c^{\p}_{i}" if self.single_partype else r"c^{\p}_{j,i}"
-            vars_and_params_.append({"Group" : 1, "Symbol": symbol_name_, "Description": r"particle liquid concentration", "Unit": r"\frac{mol}{m^3}", "Dependence" : state_deps, "Domain" : eq.full_particle_conc_domain(column_resolution=self.interstitial_volume_resolution, particle_resolution=self.resolution, hasCore=self.has_core, with_par_index=False, with_time_domain=True)})
+            vars_and_params_.append({"Group" : 1, "Symbol": symbol_name_, "Description": r"particle liquid concentration", "Unit": r"\frac{mol}{m^3}", "Dependence" : state_deps, "Domain" : eq.full_particle_conc_domain(column_resolution=self.interstitial_volume_resolution, particle_resolution=self.resolution, hasCore=self.has_core, with_par_index=False, with_time_domain=True, column_type=self.column_type)})
             
         if self.resolution == "1D":
             vars_and_params_.append({"Group" : 0, "Symbol": r"r", "Description": r"radial particle coordinate", "Unit": r"m", "Dependence": r"\text{independent variable}", "Property": r""})
@@ -90,7 +91,7 @@ class Particle:
 
         if self.has_binding:
             symbol_name_ = r"c^{\s}_{i}" if self.single_partype else r"c^{\s}_{j,i}"
-            vars_and_params_.append({"Group" : 1, "Symbol": symbol_name_, "Description": r"particle solid concentration", "Unit": r"\frac{mol}{m^3}", "Dependence" : state_deps, "Domain" : eq.full_particle_conc_domain(column_resolution=self.interstitial_volume_resolution, particle_resolution=self.resolution, hasCore=self.has_core, with_par_index=False, with_time_domain=True)})
+            vars_and_params_.append({"Group" : 1, "Symbol": symbol_name_, "Description": r"particle solid concentration", "Unit": r"\frac{mol}{m^3}", "Dependence" : state_deps, "Domain" : eq.full_particle_conc_domain(column_resolution=self.interstitial_volume_resolution, particle_resolution=self.resolution, hasCore=self.has_core, with_par_index=False, with_time_domain=True, column_type=self.column_type)})
 
             if self.binding_model == "Arbitrary":
                 symbol_name_ = r"f^\mathrm{bind}_{j,i}" if self.PTD else r"f^\mathrm{bind}_{i}"

--- a/src/model_particle.py
+++ b/src/model_particle.py
@@ -67,7 +67,12 @@ class Particle:
         
         state_deps = r"t"
         if self.interstitial_volume_resolution == "1D":
-            state_deps = r"t, \rho" if self.column_type == "Radial" else r"t, z"
+            if self.column_type == "Radial":
+                state_deps = r"t, \rho"
+            elif self.column_type == "Frustum":
+                state_deps = r"t, x"
+            else:
+                state_deps = r"t, z"
         if self.interstitial_volume_resolution == "2D":
             state_deps = r"t, z, \rho"
         if self.interstitial_volume_resolution == "3D":

--- a/test/data/EquationGenerator_configs/Frustum_GRM.json
+++ b/test/data/EquationGenerator_configs/Frustum_GRM.json
@@ -1,0 +1,15 @@
+{
+    "advanced_mode": "Off",
+    "column_type": "Frustum",
+    "column_resolution": "1D (axial coordinate)",
+    "add_particles": "Yes",
+    "has_binding": "Yes",
+    "has_axial_dispersion": "Yes",
+    "has_surfDiff": "No",
+    "model_assumptions": true,
+    "nonlimiting_filmDiff": "No",
+    "particle_resolution": "1D (radial coordinate)",
+    "req_binding": "Kinetic",
+    "show_eq_description": true,
+    "var_format": "CADET"
+}

--- a/test/data/EquationGenerator_configs/Frustum_Plug_Flow.json
+++ b/test/data/EquationGenerator_configs/Frustum_Plug_Flow.json
@@ -1,0 +1,10 @@
+{
+    "advanced_mode": "Off",
+    "column_type": "Frustum",
+    "column_resolution": "1D (axial coordinate)",
+    "add_particles": "No",
+    "has_axial_dispersion": "No",
+    "model_assumptions": true,
+    "show_eq_description": true,
+    "var_format": "CADET"
+}

--- a/test/data/EquationGenerator_configs/Radial_Dispersive_Plug_Flow.json
+++ b/test/data/EquationGenerator_configs/Radial_Dispersive_Plug_Flow.json
@@ -1,0 +1,10 @@
+{
+    "advanced_mode": "Off",
+    "column_type": "Radial flow cylinder",
+    "column_resolution": "1D (radial coordinate)",
+    "add_particles": "No",
+    "has_axial_dispersion": "Yes",
+    "model_assumptions": true,
+    "show_eq_description": true,
+    "var_format": "CADET"
+}

--- a/test/data/EquationGenerator_configs/Radial_GRM.json
+++ b/test/data/EquationGenerator_configs/Radial_GRM.json
@@ -1,0 +1,15 @@
+{
+    "advanced_mode": "Off",
+    "column_type": "Radial flow cylinder",
+    "column_resolution": "1D (radial coordinate)",
+    "add_particles": "Yes",
+    "has_binding": "Yes",
+    "has_axial_dispersion": "Yes",
+    "has_surfDiff": "No",
+    "model_assumptions": true,
+    "nonlimiting_filmDiff": "No",
+    "particle_resolution": "1D (radial coordinate)",
+    "req_binding": "Kinetic",
+    "show_eq_description": true,
+    "var_format": "CADET"
+}

--- a/test/data/EquationGenerator_configs/Radial_LRM.json
+++ b/test/data/EquationGenerator_configs/Radial_LRM.json
@@ -1,0 +1,14 @@
+{
+    "advanced_mode": "Off",
+    "column_type": "Radial flow cylinder",
+    "column_resolution": "1D (radial coordinate)",
+    "add_particles": "Yes",
+    "has_binding": "Yes",
+    "has_axial_dispersion": "Yes",
+    "model_assumptions": true,
+    "nonlimiting_filmDiff": "Yes",
+    "particle_resolution": "0D (homogeneous)",
+    "req_binding": "Kinetic",
+    "show_eq_description": true,
+    "var_format": "CADET"
+}

--- a/test/data/EquationGenerator_configs/Radial_LRMP.json
+++ b/test/data/EquationGenerator_configs/Radial_LRMP.json
@@ -1,0 +1,14 @@
+{
+    "advanced_mode": "Off",
+    "column_type": "Radial flow cylinder",
+    "column_resolution": "1D (radial coordinate)",
+    "add_particles": "Yes",
+    "has_binding": "Yes",
+    "has_axial_dispersion": "Yes",
+    "model_assumptions": true,
+    "nonlimiting_filmDiff": "No",
+    "particle_resolution": "0D (homogeneous)",
+    "req_binding": "Kinetic",
+    "show_eq_description": true,
+    "var_format": "CADET"
+}

--- a/test/data/EquationGenerator_configs/Radial_Plug_Flow.json
+++ b/test/data/EquationGenerator_configs/Radial_Plug_Flow.json
@@ -1,0 +1,10 @@
+{
+    "advanced_mode": "Off",
+    "column_type": "Radial flow cylinder",
+    "column_resolution": "1D (radial coordinate)",
+    "add_particles": "No",
+    "has_axial_dispersion": "No",
+    "model_assumptions": true,
+    "show_eq_description": true,
+    "var_format": "CADET"
+}

--- a/test/data/ref_latex/Frustum_GRM.tex
+++ b/test/data/ref_latex/Frustum_GRM.tex
@@ -44,7 +44,7 @@ with boundary conditions
 \frac{v}{r(x)^2} c_{\mathrm{in},i} &= \left.\left( \frac{v}{r(x)^2} c^{\mathrm{b}}_i - D^{\mathrm{ax}}_{i} \frac{\partial c^{\mathrm{b}}_i}{\partial x}\right)\right|_{x=0} & &\qquad\text{on }(0, T^{\mathrm{end}}),\\
                0 &= - D^{\mathrm{ax}}_{i} \left. \frac{\partial c^{\mathrm{b}}_i}{\partial x} \right|_{x=L} & &\qquad\text{on }(0, T^{\mathrm{end}}).
 \end{alignat}
-Here, $t\in (0, T^{\mathrm{end}})$ is the time coordinate, $x\in (0, L)$ is the axial coordinate, $R^\mathrm{p}> 0$ is the particle radius, $c^{\mathrm{b}}_i\colon (0, T^\mathrm{end})\times (0, L) \mapsto \mathbb{R}$ is the bulk liquid concentration, $Q> 0$ is the volumetric flow rate, $r(x) = R^0 + \frac{R^L - R^0}{L} x$ is the column radius function, $\varepsilon^{\mathrm{c}}\in (0, 1)$ is the column porosity, $v:= \frac{Q}{\pi}$ is the velocity coefficient, $D^\mathrm{ax}_i\geq 0$ is the axial dispersion coefficient, and $k^\mathrm{f}_{i}\geq 0$ is the film diffusion coefficient.
+Here, $t\in (0, T^{\mathrm{end}})$ is the time coordinate, $x\in (0, L)$ is the axial coordinate, $R^\mathrm{p}> 0$ is the particle radius, $c^{\mathrm{b}}_i\colon (0, T^\mathrm{end})\times (0, L) \mapsto \mathbb{R}$ is the bulk liquid concentration, $Q> 0$ is the volumetric flow rate, $R(x) = R^0 + \frac{R^L - R^0}{L} x$ is the column radius function, $\varepsilon^{\mathrm{c}}\in (0, 1)$ is the column porosity, $v:= \frac{Q}{\pi}$ is the velocity coefficient, $D^\mathrm{ax}_i\geq 0$ is the axial dispersion coefficient, and $k^\mathrm{f}_{i}\geq 0$ is the film diffusion coefficient.
 In the particles, mass transfer is governed by diffusion-reaction equations in $(0, T^\mathrm{end}) \times (0, L)\times (0, R^{\mathrm{p}})$ and for all components
 
 \begin{align}

--- a/test/data/ref_latex/Frustum_GRM.tex
+++ b/test/data/ref_latex/Frustum_GRM.tex
@@ -1,0 +1,63 @@
+\documentclass{article}
+
+\usepackage{amssymb,amsmath,mleftright}
+
+\begin{document}
+
+General model assumptions:
+\begin{itemize}
+\item the fluid density and viscosity are constant in time and space (implies incompressibility);
+\item the fluid flow is laminar;
+\item the column is operated under constant conditions (e.g., temperature, flow rate);
+\item the process is isothermal (i.e., there are no thermal effects);
+\item diffusion does not depend on the concentration of the components, viscosity of the fluid, or pressure;
+\item the fluid in the particles is stagnant (i.e., there is no convective flow);
+\item the porous particles are spherical, rigid, and do not move;
+\item the particles are homogeneous and of uniform porosity;
+\item all components access the same particle volume;
+\item the partial molar volumes are the same in mobile and solid phase;
+\item the binding model parameters do not depend on pressure and are constant along the column;
+\item the solvent is not adsorbed;
+\end{itemize}
+
+
+Specific model assumptions:
+\begin{itemize}
+\item the fluid only flows in the axial direction of the column (i.e., there is no flow in the radial and angular direction);
+\item the column has a conical frustum shape with linearly varying radius $r(z) = R^0 + \frac{z}{L}(R^L - R^0)$;
+\item the particles form a continuum inside the column (i.e., there is interstitial and particle volume at every point in the column);
+\item the column is radially symmetric and homogeneous (i.e., concentration profiles and parameters only depend on the axial position);
+\item the interstitial liquid phase concentration is spatially constant on the outer particle surface;
+\item there is no surface diffusion (i.e. adsorbed molecules are spatially constant);
+\end{itemize}
+
+
+\section*{Frustum General Rate Model}
+Consider a conical frustum column of length $L > 0$ with inlet radius $R^0 > 0$ and outlet radius $R^L > 0$ packed with spherical particles, and observed over a time interval $(0, T^{\mathrm{end}})$.
+In the interstitial volume, mass transfer is governed by the following convection-diffusion-reaction equations in $(0, T^\mathrm{end})\times (0, L)$ and for all components $i\in\{1, \dots, N^{\mathrm{c}} \}$
+\begin{align}
+\varepsilon^{\mathrm{c}} \frac{\partial c^{\mathrm{b}}_i}{\partial t} = - \frac{v}{r(z)^2} \frac{\partial \left( \varepsilon^{\mathrm{c}} c^{\mathrm{b}}_i \right)}{\partial z} + \frac{1}{r(z)^2} \frac{\partial}{\partial z} \left( r(z)^2 \varepsilon^{\mathrm{c}} D^{\mathrm{ax}}_{i} \frac{\partial c^{\mathrm{b}}_i}{\partial z} \right)- \left(1 - \varepsilon^{\mathrm{c}} \right) \frac{3}{R^{\mathrm{p}}} k^{\mathrm{f}}_{i} \left(c^{\mathrm{b}}_i - \left. c^{\mathrm{p}}_{i} \right|_{r = R^{\mathrm{p}}} \right),
+\end{align}
+with boundary conditions
+
+\begin{alignat}{2}
+\frac{v}{r(z)^2} c_{\mathrm{in},i} &= \left.\left( \frac{v}{r(z)^2} c^{\mathrm{b}}_i - D^{\mathrm{ax}}_{i} \frac{\partial c^{\mathrm{b}}_i}{\partial z}\right)\right|_{z=0} & &\qquad\text{on }(0, T^{\mathrm{end}}),\\
+               0 &= - D^{\mathrm{ax}}_{i} \left. \frac{\partial c^{\mathrm{b}}_i}{\partial z} \right|_{z=L} & &\qquad\text{on }(0, T^{\mathrm{end}}).
+\end{alignat}
+Here, $t\in (0, T^{\mathrm{end}})$ is the time coordinate, $z\in (0, L)$ is the axial coordinate, $R^\mathrm{p}> 0$ is the particle radius, $c^{\mathrm{b}}_i\colon (0, T^\mathrm{end})\times (0, L) \mapsto \mathbb{R}$ is the bulk liquid concentration, $r(z)$ is the column radius function, $r(z) = R^0 + \frac{z}{L}(R^L - R^0)$, $\varepsilon^{\mathrm{c}}\in (0, 1)$ is the column porosity, $v> 0$ is the velocity coefficient, $v = \frac{Q}{\pi}$, $D^\mathrm{ax}_i\geq 0$ is the axial dispersion coefficient, and $k^\mathrm{f}_{i}\geq 0$ is the film diffusion coefficient.
+In the particles, mass transfer is governed by diffusion-reaction equations in $(0, T^\mathrm{end}) \times (0, L)\times (0, R^{\mathrm{p}})$ and for all components
+
+\begin{align}
+\frac{\partial c^{\mathrm{p}}_{i}}{\partial t} &= \frac{1}{r^2} \frac{\partial }{\partial r} \left( r^2 D_{i}^{\mathrm{p}} \frac{\partial c^{\mathrm{p}}_{i}}{\partial r} \right) - \frac{1 - \varepsilon^{\mathrm{p}}}{\varepsilon^{\mathrm{p}}}f^{\mathrm{bind}}_{i}\left( \vec{c}^{\mathrm{p}}, \vec{c}^{\mathrm{s}} \right), \\
+\frac{\partial c^{\mathrm{s}}_{i}}{\partial t} &= f^{\mathrm{bind}}_{i}\left( \vec{c}^{\mathrm{p}}, \vec{c}^{\mathrm{s}} \right),
+\end{align}
+
+with boundary conditions
+\begin{align}
+- \left. \left( D^{\mathrm{p}}_{i} \frac{\partial c^{\mathrm{p}}_{i}}{\partial r} \right) \right|_{r=0}
+&= 0, \\
+\varepsilon^{\mathrm{p}} \left. \left( D^{\mathrm{p}}_{i} \frac{\partial c^{\mathrm{p}}_{i}}{\partial r} \right)\right|_{r = R^{\mathrm{p}}_{}}
+               &= k^{\mathrm{f}}_{i} \left. \left( c^{\mathrm{b}}_i - c^{\mathrm{p}}_{i} \right|_{r = R^{\mathrm{p}}_{}} \right).\end{align}
+Here, $r$ is the radial particle coordinate, $c^{\mathrm{p}}_{i}\colon (0, T^\mathrm{end}) \times (0, L)\times (0, R^{\mathrm{p}}) \mapsto \mathbb{R}$ is the particle liquid concentration, $c^{\mathrm{s}}_{i}\colon (0, T^\mathrm{end}) \times (0, L)\times (0, R^{\mathrm{p}}) \mapsto \mathbb{R}$ is the particle solid concentration, $\varepsilon^{\mathrm{p}}\in (0, 1)$ is the particle porosity, $D^\mathrm{p}_{i}> 0$ is the particle diffusion coefficient, $f^\mathrm{bind}_{i}$ is the adsorption isotherm function, $\vec{c}^\mathrm{p}$ is the particle liquid components vector, and $\vec{c}^\mathrm{s}$ is the particle solid components vector.
+Consistent initial values for all solution variables (concentrations) are defined at $t = 0$.
+\end{document}

--- a/test/data/ref_latex/Frustum_GRM.tex
+++ b/test/data/ref_latex/Frustum_GRM.tex
@@ -24,7 +24,7 @@ General model assumptions:
 Specific model assumptions:
 \begin{itemize}
 \item the fluid only flows in the axial direction of the column (i.e., there is no flow in the radial and angular direction);
-\item the column has a conical frustum shape with linearly varying radius;
+\item the column has a conical frustum shape where $r(x) = R^0 + \frac{R^L - R^0}{L} x$ is the column radius function;
 \item the particles form a continuum inside the column (i.e., there is interstitial and particle volume at every point in the column);
 \item the column is radially symmetric and homogeneous (i.e., concentration profiles and parameters only depend on the axial position);
 \item the interstitial liquid phase concentration is spatially constant on the outer particle surface;
@@ -44,7 +44,7 @@ with boundary conditions
 \frac{v}{r(x)^2} c_{\mathrm{in},i} &= \left.\left( \frac{v}{r(x)^2} c^{\mathrm{b}}_i - D^{\mathrm{ax}}_{i} \frac{\partial c^{\mathrm{b}}_i}{\partial x}\right)\right|_{x=0} & &\qquad\text{on }(0, T^{\mathrm{end}}),\\
                0 &= - D^{\mathrm{ax}}_{i} \left. \frac{\partial c^{\mathrm{b}}_i}{\partial x} \right|_{x=L} & &\qquad\text{on }(0, T^{\mathrm{end}}).
 \end{alignat}
-Here, $t\in (0, T^{\mathrm{end}})$ is the time coordinate, $x\in (0, L)$ is the axial coordinate, $R^\mathrm{p}> 0$ is the particle radius, $c^{\mathrm{b}}_i\colon (0, T^\mathrm{end})\times (0, L) \mapsto \mathbb{R}$ is the bulk liquid concentration, $Q> 0$ is the volumetric flow rate, $r(x)$ is the column radius function, $r(x) = R^0 + \frac{R^L - R^0}{L} x$, $\varepsilon^{\mathrm{c}}\in (0, 1)$ is the column porosity, $v:= \frac{Q}{\pi}$ is the velocity coefficient, $D^\mathrm{ax}_i\geq 0$ is the axial dispersion coefficient, and $k^\mathrm{f}_{i}\geq 0$ is the film diffusion coefficient.
+Here, $t\in (0, T^{\mathrm{end}})$ is the time coordinate, $x\in (0, L)$ is the axial coordinate, $R^\mathrm{p}> 0$ is the particle radius, $c^{\mathrm{b}}_i\colon (0, T^\mathrm{end})\times (0, L) \mapsto \mathbb{R}$ is the bulk liquid concentration, $Q> 0$ is the volumetric flow rate, $r(x)$ is the column radius function, $\varepsilon^{\mathrm{c}}\in (0, 1)$ is the column porosity, $v:= \frac{Q}{\pi}$ is the velocity coefficient, $D^\mathrm{ax}_i\geq 0$ is the axial dispersion coefficient, and $k^\mathrm{f}_{i}\geq 0$ is the film diffusion coefficient.
 In the particles, mass transfer is governed by diffusion-reaction equations in $(0, T^\mathrm{end}) \times (0, L)\times (0, R^{\mathrm{p}})$ and for all components
 
 \begin{align}

--- a/test/data/ref_latex/Frustum_GRM.tex
+++ b/test/data/ref_latex/Frustum_GRM.tex
@@ -24,7 +24,7 @@ General model assumptions:
 Specific model assumptions:
 \begin{itemize}
 \item the fluid only flows in the axial direction of the column (i.e., there is no flow in the radial and angular direction);
-\item the column has a conical frustum shape with linearly varying radius $r(z) = R^0 + \frac{z}{L}(R^L - R^0)$;
+\item the column has a conical frustum shape with linearly varying radius;
 \item the particles form a continuum inside the column (i.e., there is interstitial and particle volume at every point in the column);
 \item the column is radially symmetric and homogeneous (i.e., concentration profiles and parameters only depend on the axial position);
 \item the interstitial liquid phase concentration is spatially constant on the outer particle surface;
@@ -36,15 +36,15 @@ Specific model assumptions:
 Consider a conical frustum column of length $L > 0$ with inlet radius $R^0 > 0$ and outlet radius $R^L > 0$ packed with spherical particles, and observed over a time interval $(0, T^{\mathrm{end}})$.
 In the interstitial volume, mass transfer is governed by the following convection-diffusion-reaction equations in $(0, T^\mathrm{end})\times (0, L)$ and for all components $i\in\{1, \dots, N^{\mathrm{c}} \}$
 \begin{align}
-\varepsilon^{\mathrm{c}} \frac{\partial c^{\mathrm{b}}_i}{\partial t} = - \frac{v}{r(z)^2} \frac{\partial \left( \varepsilon^{\mathrm{c}} c^{\mathrm{b}}_i \right)}{\partial z} + \frac{1}{r(z)^2} \frac{\partial}{\partial z} \left( r(z)^2 \varepsilon^{\mathrm{c}} D^{\mathrm{ax}}_{i} \frac{\partial c^{\mathrm{b}}_i}{\partial z} \right)- \left(1 - \varepsilon^{\mathrm{c}} \right) \frac{3}{R^{\mathrm{p}}} k^{\mathrm{f}}_{i} \left(c^{\mathrm{b}}_i - \left. c^{\mathrm{p}}_{i} \right|_{r = R^{\mathrm{p}}} \right),
+\varepsilon^{\mathrm{c}} \frac{\partial c^{\mathrm{b}}_i}{\partial t} = - \frac{v}{r(x)^2} \frac{\partial \left( \varepsilon^{\mathrm{c}} c^{\mathrm{b}}_i \right)}{\partial x} + \frac{1}{r(x)^2} \frac{\partial}{\partial x} \left( r(x)^2 \varepsilon^{\mathrm{c}} D^{\mathrm{ax}}_{i} \frac{\partial c^{\mathrm{b}}_i}{\partial x} \right)- \left(1 - \varepsilon^{\mathrm{c}} \right) \frac{3}{R^{\mathrm{p}}} k^{\mathrm{f}}_{i} \left(c^{\mathrm{b}}_i - \left. c^{\mathrm{p}}_{i} \right|_{r = R^{\mathrm{p}}} \right),
 \end{align}
 with boundary conditions
 
 \begin{alignat}{2}
-\frac{v}{r(z)^2} c_{\mathrm{in},i} &= \left.\left( \frac{v}{r(z)^2} c^{\mathrm{b}}_i - D^{\mathrm{ax}}_{i} \frac{\partial c^{\mathrm{b}}_i}{\partial z}\right)\right|_{z=0} & &\qquad\text{on }(0, T^{\mathrm{end}}),\\
-               0 &= - D^{\mathrm{ax}}_{i} \left. \frac{\partial c^{\mathrm{b}}_i}{\partial z} \right|_{z=L} & &\qquad\text{on }(0, T^{\mathrm{end}}).
+\frac{v}{r(x)^2} c_{\mathrm{in},i} &= \left.\left( \frac{v}{r(x)^2} c^{\mathrm{b}}_i - D^{\mathrm{ax}}_{i} \frac{\partial c^{\mathrm{b}}_i}{\partial x}\right)\right|_{x=0} & &\qquad\text{on }(0, T^{\mathrm{end}}),\\
+               0 &= - D^{\mathrm{ax}}_{i} \left. \frac{\partial c^{\mathrm{b}}_i}{\partial x} \right|_{x=L} & &\qquad\text{on }(0, T^{\mathrm{end}}).
 \end{alignat}
-Here, $t\in (0, T^{\mathrm{end}})$ is the time coordinate, $z\in (0, L)$ is the axial coordinate, $R^\mathrm{p}> 0$ is the particle radius, $c^{\mathrm{b}}_i\colon (0, T^\mathrm{end})\times (0, L) \mapsto \mathbb{R}$ is the bulk liquid concentration, $r(z)$ is the column radius function, $r(z) = R^0 + \frac{z}{L}(R^L - R^0)$, $\varepsilon^{\mathrm{c}}\in (0, 1)$ is the column porosity, $v> 0$ is the velocity coefficient, $v = \frac{Q}{\pi}$, $D^\mathrm{ax}_i\geq 0$ is the axial dispersion coefficient, and $k^\mathrm{f}_{i}\geq 0$ is the film diffusion coefficient.
+Here, $t\in (0, T^{\mathrm{end}})$ is the time coordinate, $x\in (0, L)$ is the axial coordinate, $R^\mathrm{p}> 0$ is the particle radius, $c^{\mathrm{b}}_i\colon (0, T^\mathrm{end})\times (0, L) \mapsto \mathbb{R}$ is the bulk liquid concentration, $Q> 0$ is the volumetric flow rate, $r(x)$ is the column radius function, $r(x) = R^0 + \frac{R^L - R^0}{L} x$, $\varepsilon^{\mathrm{c}}\in (0, 1)$ is the column porosity, $v:= \frac{Q}{\pi}$ is the velocity coefficient, $D^\mathrm{ax}_i\geq 0$ is the axial dispersion coefficient, and $k^\mathrm{f}_{i}\geq 0$ is the film diffusion coefficient.
 In the particles, mass transfer is governed by diffusion-reaction equations in $(0, T^\mathrm{end}) \times (0, L)\times (0, R^{\mathrm{p}})$ and for all components
 
 \begin{align}

--- a/test/data/ref_latex/Frustum_GRM.tex
+++ b/test/data/ref_latex/Frustum_GRM.tex
@@ -24,7 +24,7 @@ General model assumptions:
 Specific model assumptions:
 \begin{itemize}
 \item the fluid only flows in the axial direction of the column (i.e., there is no flow in the radial and angular direction);
-\item the column has a conical frustum shape where $r(x) = R^0 + \frac{R^L - R^0}{L} x$ is the column radius function;
+\item the column has a conical frustum shape with linearly varying radius;
 \item the particles form a continuum inside the column (i.e., there is interstitial and particle volume at every point in the column);
 \item the column is radially symmetric and homogeneous (i.e., concentration profiles and parameters only depend on the axial position);
 \item the interstitial liquid phase concentration is spatially constant on the outer particle surface;
@@ -44,7 +44,7 @@ with boundary conditions
 \frac{v}{r(x)^2} c_{\mathrm{in},i} &= \left.\left( \frac{v}{r(x)^2} c^{\mathrm{b}}_i - D^{\mathrm{ax}}_{i} \frac{\partial c^{\mathrm{b}}_i}{\partial x}\right)\right|_{x=0} & &\qquad\text{on }(0, T^{\mathrm{end}}),\\
                0 &= - D^{\mathrm{ax}}_{i} \left. \frac{\partial c^{\mathrm{b}}_i}{\partial x} \right|_{x=L} & &\qquad\text{on }(0, T^{\mathrm{end}}).
 \end{alignat}
-Here, $t\in (0, T^{\mathrm{end}})$ is the time coordinate, $x\in (0, L)$ is the axial coordinate, $R^\mathrm{p}> 0$ is the particle radius, $c^{\mathrm{b}}_i\colon (0, T^\mathrm{end})\times (0, L) \mapsto \mathbb{R}$ is the bulk liquid concentration, $Q> 0$ is the volumetric flow rate, $r(x)$ is the column radius function, $\varepsilon^{\mathrm{c}}\in (0, 1)$ is the column porosity, $v:= \frac{Q}{\pi}$ is the velocity coefficient, $D^\mathrm{ax}_i\geq 0$ is the axial dispersion coefficient, and $k^\mathrm{f}_{i}\geq 0$ is the film diffusion coefficient.
+Here, $t\in (0, T^{\mathrm{end}})$ is the time coordinate, $x\in (0, L)$ is the axial coordinate, $R^\mathrm{p}> 0$ is the particle radius, $c^{\mathrm{b}}_i\colon (0, T^\mathrm{end})\times (0, L) \mapsto \mathbb{R}$ is the bulk liquid concentration, $Q> 0$ is the volumetric flow rate, $r(x) = R^0 + \frac{R^L - R^0}{L} x$ is the column radius function, $\varepsilon^{\mathrm{c}}\in (0, 1)$ is the column porosity, $v:= \frac{Q}{\pi}$ is the velocity coefficient, $D^\mathrm{ax}_i\geq 0$ is the axial dispersion coefficient, and $k^\mathrm{f}_{i}\geq 0$ is the film diffusion coefficient.
 In the particles, mass transfer is governed by diffusion-reaction equations in $(0, T^\mathrm{end}) \times (0, L)\times (0, R^{\mathrm{p}})$ and for all components
 
 \begin{align}

--- a/test/data/ref_latex/Frustum_Plug_Flow.tex
+++ b/test/data/ref_latex/Frustum_Plug_Flow.tex
@@ -18,7 +18,7 @@ General model assumptions:
 Specific model assumptions:
 \begin{itemize}
 \item the fluid only flows in the axial direction of the column (i.e., there is no flow in the radial and angular direction);
-\item the column has a conical frustum shape with linearly varying radius;
+\item the column has a conical frustum shape where $r(x) = R^0 + \frac{R^L - R^0}{L} x$ is the column radius function;
 \item the column is radially symmetric and homogeneous (i.e., concentration profiles and parameters only depend on the axial position);
 \end{itemize}
 
@@ -34,6 +34,6 @@ with boundary conditions
 \begin{alignat}{2}
 \frac{v}{r(x)^2} c_{\mathrm{in},i} &= \left.\left( \frac{v}{r(x)^2} c^{\mathrm{b}}_i \right)\right|_{x=0} & &\qquad\text{on }(0, T^{\mathrm{end}}).
 \end{alignat}
-Here, $t\in (0, T^{\mathrm{end}})$ is the time coordinate, $x\in (0, L)$ is the axial coordinate, $c^{\mathrm{b}}_i\colon (0, T^\mathrm{end})\times (0, L) \mapsto \mathbb{R}$ is the bulk liquid concentration, $Q> 0$ is the volumetric flow rate, $r(x)$ is the column radius function, $r(x) = R^0 + \frac{R^L - R^0}{L} x$, and $v:= \frac{Q}{\pi}$ is the velocity coefficient.
+Here, $t\in (0, T^{\mathrm{end}})$ is the time coordinate, $x\in (0, L)$ is the axial coordinate, $c^{\mathrm{b}}_i\colon (0, T^\mathrm{end})\times (0, L) \mapsto \mathbb{R}$ is the bulk liquid concentration, $Q> 0$ is the volumetric flow rate, $r(x)$ is the column radius function, and $v:= \frac{Q}{\pi}$ is the velocity coefficient.
 Consistent initial values for all solution variables (concentrations) are defined at $t = 0$.
 \end{document}

--- a/test/data/ref_latex/Frustum_Plug_Flow.tex
+++ b/test/data/ref_latex/Frustum_Plug_Flow.tex
@@ -18,7 +18,7 @@ General model assumptions:
 Specific model assumptions:
 \begin{itemize}
 \item the fluid only flows in the axial direction of the column (i.e., there is no flow in the radial and angular direction);
-\item the column has a conical frustum shape with linearly varying radius $r(z) = R^0 + \frac{z}{L}(R^L - R^0)$;
+\item the column has a conical frustum shape with linearly varying radius;
 \item the column is radially symmetric and homogeneous (i.e., concentration profiles and parameters only depend on the axial position);
 \end{itemize}
 
@@ -27,13 +27,13 @@ Specific model assumptions:
 Consider a conical frustum column of length $L > 0$ with inlet radius $R^0 > 0$ and outlet radius $R^L > 0$ filled with a liquid phase, and observed over a time interval $(0, T^{\mathrm{end}})$.
 In the interstitial volume, mass transfer is governed by the following convection equations in $(0, T^\mathrm{end})\times (0, L)$ and for all components $i\in\{1, \dots, N^{\mathrm{c}} \}$
 \begin{align}
-\varepsilon^{\mathrm{c}} \frac{\partial c^{\mathrm{b}}_i}{\partial t} = - \frac{v}{r(z)^2} \frac{\partial \left( \varepsilon^{\mathrm{c}} c^{\mathrm{b}}_i \right)}{\partial z},
+\varepsilon^{\mathrm{c}} \frac{\partial c^{\mathrm{b}}_i}{\partial t} = - \frac{v}{r(x)^2} \frac{\partial \left( \varepsilon^{\mathrm{c}} c^{\mathrm{b}}_i \right)}{\partial x},
 \end{align}
 with boundary conditions
 
 \begin{alignat}{2}
-\frac{v}{r(z)^2} c_{\mathrm{in},i} &= \left.\left( \frac{v}{r(z)^2} c^{\mathrm{b}}_i \right)\right|_{z=0} & &\qquad\text{on }(0, T^{\mathrm{end}}).
+\frac{v}{r(x)^2} c_{\mathrm{in},i} &= \left.\left( \frac{v}{r(x)^2} c^{\mathrm{b}}_i \right)\right|_{x=0} & &\qquad\text{on }(0, T^{\mathrm{end}}).
 \end{alignat}
-Here, $t\in (0, T^{\mathrm{end}})$ is the time coordinate, $z\in (0, L)$ is the axial coordinate, $c^{\mathrm{b}}_i\colon (0, T^\mathrm{end})\times (0, L) \mapsto \mathbb{R}$ is the bulk liquid concentration, $r(z)$ is the column radius function, $r(z) = R^0 + \frac{z}{L}(R^L - R^0)$, and $v> 0$ is the velocity coefficient, $v = \frac{Q}{\pi}$.
+Here, $t\in (0, T^{\mathrm{end}})$ is the time coordinate, $x\in (0, L)$ is the axial coordinate, $c^{\mathrm{b}}_i\colon (0, T^\mathrm{end})\times (0, L) \mapsto \mathbb{R}$ is the bulk liquid concentration, $Q> 0$ is the volumetric flow rate, $r(x)$ is the column radius function, $r(x) = R^0 + \frac{R^L - R^0}{L} x$, and $v:= \frac{Q}{\pi}$ is the velocity coefficient.
 Consistent initial values for all solution variables (concentrations) are defined at $t = 0$.
 \end{document}

--- a/test/data/ref_latex/Frustum_Plug_Flow.tex
+++ b/test/data/ref_latex/Frustum_Plug_Flow.tex
@@ -34,6 +34,6 @@ with boundary conditions
 \begin{alignat}{2}
 \frac{v}{r(x)^2} c_{\mathrm{in},i} &= \left.\left( \frac{v}{r(x)^2} c^{\mathrm{b}}_i \right)\right|_{x=0} & &\qquad\text{on }(0, T^{\mathrm{end}}).
 \end{alignat}
-Here, $t\in (0, T^{\mathrm{end}})$ is the time coordinate, $x\in (0, L)$ is the axial coordinate, $c^{\mathrm{b}}_i\colon (0, T^\mathrm{end})\times (0, L) \mapsto \mathbb{R}$ is the bulk liquid concentration, $Q> 0$ is the volumetric flow rate, $r(x) = R^0 + \frac{R^L - R^0}{L} x$ is the column radius function, and $v:= \frac{Q}{\pi}$ is the velocity coefficient.
+Here, $t\in (0, T^{\mathrm{end}})$ is the time coordinate, $x\in (0, L)$ is the axial coordinate, $c^{\mathrm{b}}_i\colon (0, T^\mathrm{end})\times (0, L) \mapsto \mathbb{R}$ is the bulk liquid concentration, $Q> 0$ is the volumetric flow rate, $R(x) = R^0 + \frac{R^L - R^0}{L} x$ is the column radius function, and $v:= \frac{Q}{\pi}$ is the velocity coefficient.
 Consistent initial values for all solution variables (concentrations) are defined at $t = 0$.
 \end{document}

--- a/test/data/ref_latex/Frustum_Plug_Flow.tex
+++ b/test/data/ref_latex/Frustum_Plug_Flow.tex
@@ -18,7 +18,7 @@ General model assumptions:
 Specific model assumptions:
 \begin{itemize}
 \item the fluid only flows in the axial direction of the column (i.e., there is no flow in the radial and angular direction);
-\item the column has a conical frustum shape where $r(x) = R^0 + \frac{R^L - R^0}{L} x$ is the column radius function;
+\item the column has a conical frustum shape with linearly varying radius;
 \item the column is radially symmetric and homogeneous (i.e., concentration profiles and parameters only depend on the axial position);
 \end{itemize}
 
@@ -34,6 +34,6 @@ with boundary conditions
 \begin{alignat}{2}
 \frac{v}{r(x)^2} c_{\mathrm{in},i} &= \left.\left( \frac{v}{r(x)^2} c^{\mathrm{b}}_i \right)\right|_{x=0} & &\qquad\text{on }(0, T^{\mathrm{end}}).
 \end{alignat}
-Here, $t\in (0, T^{\mathrm{end}})$ is the time coordinate, $x\in (0, L)$ is the axial coordinate, $c^{\mathrm{b}}_i\colon (0, T^\mathrm{end})\times (0, L) \mapsto \mathbb{R}$ is the bulk liquid concentration, $Q> 0$ is the volumetric flow rate, $r(x)$ is the column radius function, and $v:= \frac{Q}{\pi}$ is the velocity coefficient.
+Here, $t\in (0, T^{\mathrm{end}})$ is the time coordinate, $x\in (0, L)$ is the axial coordinate, $c^{\mathrm{b}}_i\colon (0, T^\mathrm{end})\times (0, L) \mapsto \mathbb{R}$ is the bulk liquid concentration, $Q> 0$ is the volumetric flow rate, $r(x) = R^0 + \frac{R^L - R^0}{L} x$ is the column radius function, and $v:= \frac{Q}{\pi}$ is the velocity coefficient.
 Consistent initial values for all solution variables (concentrations) are defined at $t = 0$.
 \end{document}

--- a/test/data/ref_latex/Frustum_Plug_Flow.tex
+++ b/test/data/ref_latex/Frustum_Plug_Flow.tex
@@ -1,0 +1,39 @@
+\documentclass{article}
+
+\usepackage{amssymb,amsmath,mleftright}
+
+\begin{document}
+
+General model assumptions:
+\begin{itemize}
+\item the fluid density and viscosity are constant in time and space (implies incompressibility);
+\item the fluid flow is laminar;
+\item the column is operated under constant conditions (e.g., temperature, flow rate);
+\item the process is isothermal (i.e., there are no thermal effects);
+\item diffusion does not depend on the concentration of the components, viscosity of the fluid, or pressure;
+\item there is no solid phase in the column (and thus no adsorption);
+\end{itemize}
+
+
+Specific model assumptions:
+\begin{itemize}
+\item the fluid only flows in the axial direction of the column (i.e., there is no flow in the radial and angular direction);
+\item the column has a conical frustum shape with linearly varying radius $r(z) = R^0 + \frac{z}{L}(R^L - R^0)$;
+\item the column is radially symmetric and homogeneous (i.e., concentration profiles and parameters only depend on the axial position);
+\end{itemize}
+
+
+\section*{Frustum Plug Flow}
+Consider a conical frustum column of length $L > 0$ with inlet radius $R^0 > 0$ and outlet radius $R^L > 0$ filled with a liquid phase, and observed over a time interval $(0, T^{\mathrm{end}})$.
+In the interstitial volume, mass transfer is governed by the following convection equations in $(0, T^\mathrm{end})\times (0, L)$ and for all components $i\in\{1, \dots, N^{\mathrm{c}} \}$
+\begin{align}
+\varepsilon^{\mathrm{c}} \frac{\partial c^{\mathrm{b}}_i}{\partial t} = - \frac{v}{r(z)^2} \frac{\partial \left( \varepsilon^{\mathrm{c}} c^{\mathrm{b}}_i \right)}{\partial z},
+\end{align}
+with boundary conditions
+
+\begin{alignat}{2}
+\frac{v}{r(z)^2} c_{\mathrm{in},i} &= \left.\left( \frac{v}{r(z)^2} c^{\mathrm{b}}_i \right)\right|_{z=0} & &\qquad\text{on }(0, T^{\mathrm{end}}).
+\end{alignat}
+Here, $t\in (0, T^{\mathrm{end}})$ is the time coordinate, $z\in (0, L)$ is the axial coordinate, $c^{\mathrm{b}}_i\colon (0, T^\mathrm{end})\times (0, L) \mapsto \mathbb{R}$ is the bulk liquid concentration, $r(z)$ is the column radius function, $r(z) = R^0 + \frac{z}{L}(R^L - R^0)$, and $v> 0$ is the velocity coefficient, $v = \frac{Q}{\pi}$.
+Consistent initial values for all solution variables (concentrations) are defined at $t = 0$.
+\end{document}

--- a/test/data/ref_latex/Radial_Dispersive_Plug_Flow.tex
+++ b/test/data/ref_latex/Radial_Dispersive_Plug_Flow.tex
@@ -27,14 +27,14 @@ Specific model assumptions:
 Consider a hollow cylindrical column with inner radius $R^{\mathrm{in}} > 0$ and outer radius $R^{\mathrm{out}} > R^{\mathrm{in}}$ filled with a liquid phase, and observed over a time interval $(0, T^{\mathrm{end}})$.
 In the interstitial volume, mass transfer is governed by the following convection-diffusion equations in $(0, T^\mathrm{end})\times (R^\mathrm{in}, R^\mathrm{out})$ and for all components $i\in\{1, \dots, N^{\mathrm{c}} \}$
 \begin{align}
-\varepsilon^{\mathrm{c}} \frac{\partial c^{\mathrm{b}}_i}{\partial t} = - \frac{v}{\rho} \frac{\partial \left( \varepsilon^{\mathrm{c}} c^{\mathrm{b}}_i \right)}{\partial \rho} + \frac{1}{\rho} \frac{\partial}{\partial \rho} \left( \rho \varepsilon^{\mathrm{c}} D^{\mathrm{ax}}_{i} \frac{\partial c^{\mathrm{b}}_i}{\partial \rho} \right),
+\varepsilon^{\mathrm{c}} \frac{\partial c^{\mathrm{b}}_i}{\partial t} = - \frac{v}{\rho} \frac{\partial \left( \varepsilon^{\mathrm{c}} c^{\mathrm{b}}_i \right)}{\partial \rho} + \frac{1}{\rho} \frac{\partial}{\partial \rho} \left( \rho \varepsilon^{\mathrm{c}} D^{\mathrm{rad}}_{i} \frac{\partial c^{\mathrm{b}}_i}{\partial \rho} \right),
 \end{align}
 with boundary conditions
 
 \begin{alignat}{2}
-v c_{\mathrm{in},i} &= \left.\left( v c^{\mathrm{b}}_i - D^{\mathrm{ax}}_{i} \frac{\partial c^{\mathrm{b}}_i}{\partial \rho}\right)\right|_{\rho=R^{\mathrm{in}}} & &\qquad\text{on }(0, T^{\mathrm{end}}),\\
-               0 &= - D^{\mathrm{ax}}_{i} \left. \frac{\partial c^{\mathrm{b}}_i}{\partial \rho} \right|_{\rho=R^{\mathrm{out}}} & &\qquad\text{on }(0, T^{\mathrm{end}}).
+v c_{\mathrm{in},i} &= \left.\left( v c^{\mathrm{b}}_i - D^{\mathrm{rad}}_{i} \frac{\partial c^{\mathrm{b}}_i}{\partial \rho}\right)\right|_{\rho=R^{\mathrm{in}}} & &\qquad\text{on }(0, T^{\mathrm{end}}),\\
+               0 &= - D^{\mathrm{rad}}_{i} \left. \frac{\partial c^{\mathrm{b}}_i}{\partial \rho} \right|_{\rho=R^{\mathrm{out}}} & &\qquad\text{on }(0, T^{\mathrm{end}}).
 \end{alignat}
-Here, $t\in (0, T^{\mathrm{end}})$ is the time coordinate, $\rho\in (R^{\mathrm{in}}, R^{\mathrm{out}})$ is the radial coordinate, $c^{\mathrm{b}}_i\colon (0, T^\mathrm{end})\times (R^\mathrm{in}, R^\mathrm{out}) \mapsto \mathbb{R}$ is the bulk liquid concentration, $v> 0$ is the velocity coefficient, $v = \frac{Q}{2 \pi L}$, and $D^\mathrm{ax}_i\geq 0$ is the axial dispersion coefficient.
+Here, $t\in (0, T^{\mathrm{end}})$ is the time coordinate, $\rho\in (R^{\mathrm{in}}, R^{\mathrm{out}})$ is the radial coordinate, $c^{\mathrm{b}}_i\colon (0, T^\mathrm{end})\times (R^\mathrm{in}, R^\mathrm{out}) \mapsto \mathbb{R}$ is the bulk liquid concentration, $v> 0$ is the velocity coefficient, $v = \frac{Q}{2 \pi L}$, and $D^\mathrm{rad}_i\geq 0$ is the radial dispersion coefficient.
 Consistent initial values for all solution variables (concentrations) are defined at $t = 0$.
 \end{document}

--- a/test/data/ref_latex/Radial_Dispersive_Plug_Flow.tex
+++ b/test/data/ref_latex/Radial_Dispersive_Plug_Flow.tex
@@ -1,0 +1,40 @@
+\documentclass{article}
+
+\usepackage{amssymb,amsmath,mleftright}
+
+\begin{document}
+
+General model assumptions:
+\begin{itemize}
+\item the fluid density and viscosity are constant in time and space (implies incompressibility);
+\item the fluid flow is laminar;
+\item the column is operated under constant conditions (e.g., temperature, flow rate);
+\item the process is isothermal (i.e., there are no thermal effects);
+\item diffusion does not depend on the concentration of the components, viscosity of the fluid, or pressure;
+\item there is no solid phase in the column (and thus no adsorption);
+\end{itemize}
+
+
+Specific model assumptions:
+\begin{itemize}
+\item the fluid only flows in the radial direction of the column (i.e., there is no flow in the axial and angular direction);
+\item the column is a hollow cylinder with inner radius $R^{\mathrm{in}}$ and outer radius $R^{\mathrm{out}}$;
+\item the column is radially symmetric and homogeneous (i.e., concentration profiles and parameters only depend on the axial position);
+\end{itemize}
+
+
+\section*{Radial Dispersive Plug Flow}
+Consider a hollow cylindrical column with inner radius $R^{\mathrm{in}} > 0$ and outer radius $R^{\mathrm{out}} > R^{\mathrm{in}}$ filled with a liquid phase, and observed over a time interval $(0, T^{\mathrm{end}})$.
+In the interstitial volume, mass transfer is governed by the following convection-diffusion equations in $(0, T^\mathrm{end})\times (R^\mathrm{in}, R^\mathrm{out})$ and for all components $i\in\{1, \dots, N^{\mathrm{c}} \}$
+\begin{align}
+\varepsilon^{\mathrm{c}} \frac{\partial c^{\mathrm{b}}_i}{\partial t} = - \frac{v}{\rho} \frac{\partial \left( \varepsilon^{\mathrm{c}} c^{\mathrm{b}}_i \right)}{\partial \rho} + \frac{1}{\rho} \frac{\partial}{\partial \rho} \left( \rho \varepsilon^{\mathrm{c}} D^{\mathrm{ax}}_{i} \frac{\partial c^{\mathrm{b}}_i}{\partial \rho} \right),
+\end{align}
+with boundary conditions
+
+\begin{alignat}{2}
+v c_{\mathrm{in},i} &= \left.\left( v c^{\mathrm{b}}_i - D^{\mathrm{ax}}_{i} \frac{\partial c^{\mathrm{b}}_i}{\partial \rho}\right)\right|_{\rho=R^{\mathrm{in}}} & &\qquad\text{on }(0, T^{\mathrm{end}}),\\
+               0 &= - D^{\mathrm{ax}}_{i} \left. \frac{\partial c^{\mathrm{b}}_i}{\partial \rho} \right|_{\rho=R^{\mathrm{out}}} & &\qquad\text{on }(0, T^{\mathrm{end}}).
+\end{alignat}
+Here, $t\in (0, T^{\mathrm{end}})$ is the time coordinate, $\rho\in (R^{\mathrm{in}}, R^{\mathrm{out}})$ is the radial coordinate, $c^{\mathrm{b}}_i\colon (0, T^\mathrm{end})\times (R^\mathrm{in}, R^\mathrm{out}) \mapsto \mathbb{R}$ is the bulk liquid concentration, $v> 0$ is the velocity coefficient, $v = \frac{Q}{2 \pi L}$, and $D^\mathrm{ax}_i\geq 0$ is the axial dispersion coefficient.
+Consistent initial values for all solution variables (concentrations) are defined at $t = 0$.
+\end{document}

--- a/test/data/ref_latex/Radial_Dispersive_Plug_Flow.tex
+++ b/test/data/ref_latex/Radial_Dispersive_Plug_Flow.tex
@@ -35,6 +35,6 @@ with boundary conditions
 v c_{\mathrm{in},i} &= \left.\left( v c^{\mathrm{b}}_i - D^{\mathrm{rad}}_{i} \frac{\partial c^{\mathrm{b}}_i}{\partial \rho}\right)\right|_{\rho=R^{\mathrm{in}}} & &\qquad\text{on }(0, T^{\mathrm{end}}),\\
                0 &= - D^{\mathrm{rad}}_{i} \left. \frac{\partial c^{\mathrm{b}}_i}{\partial \rho} \right|_{\rho=R^{\mathrm{out}}} & &\qquad\text{on }(0, T^{\mathrm{end}}).
 \end{alignat}
-Here, $t\in (0, T^{\mathrm{end}})$ is the time coordinate, $\rho\in (R^{\mathrm{in}}, R^{\mathrm{out}})$ is the radial coordinate, $c^{\mathrm{b}}_i\colon (0, T^\mathrm{end})\times (R^\mathrm{in}, R^\mathrm{out}) \mapsto \mathbb{R}$ is the bulk liquid concentration, $v> 0$ is the velocity coefficient, $v = \frac{Q}{2 \pi L}$, and $D^\mathrm{rad}_i\geq 0$ is the radial dispersion coefficient.
+Here, $t\in (0, T^{\mathrm{end}})$ is the time coordinate, $\rho\in (R^{\mathrm{in}}, R^{\mathrm{out}})$ is the radial coordinate, $c^{\mathrm{b}}_i\colon (0, T^\mathrm{end})\times (R^\mathrm{in}, R^\mathrm{out}) \mapsto \mathbb{R}$ is the bulk liquid concentration, $Q> 0$ is the volumetric flow rate, $v:= \frac{Q}{2 \pi L}$ is the velocity coefficient, and $D^\mathrm{rad}_i\geq 0$ is the radial dispersion coefficient.
 Consistent initial values for all solution variables (concentrations) are defined at $t = 0$.
 \end{document}

--- a/test/data/ref_latex/Radial_GRM.tex
+++ b/test/data/ref_latex/Radial_GRM.tex
@@ -44,7 +44,7 @@ with boundary conditions
 v c_{\mathrm{in},i} &= \left.\left( v c^{\mathrm{b}}_i - D^{\mathrm{rad}}_{i} \frac{\partial c^{\mathrm{b}}_i}{\partial \rho}\right)\right|_{\rho=R^{\mathrm{in}}} & &\qquad\text{on }(0, T^{\mathrm{end}}),\\
                0 &= - D^{\mathrm{rad}}_{i} \left. \frac{\partial c^{\mathrm{b}}_i}{\partial \rho} \right|_{\rho=R^{\mathrm{out}}} & &\qquad\text{on }(0, T^{\mathrm{end}}).
 \end{alignat}
-Here, $t\in (0, T^{\mathrm{end}})$ is the time coordinate, $\rho\in (R^{\mathrm{in}}, R^{\mathrm{out}})$ is the radial coordinate, $R^\mathrm{p}> 0$ is the particle radius, $c^{\mathrm{b}}_i\colon (0, T^\mathrm{end})\times (R^\mathrm{in}, R^\mathrm{out}) \mapsto \mathbb{R}$ is the bulk liquid concentration, $\varepsilon^{\mathrm{c}}\in (0, 1)$ is the column porosity, $v> 0$ is the velocity coefficient, $v = \frac{Q}{2 \pi L}$, $D^\mathrm{rad}_i\geq 0$ is the radial dispersion coefficient, and $k^\mathrm{f}_{i}\geq 0$ is the film diffusion coefficient.
+Here, $t\in (0, T^{\mathrm{end}})$ is the time coordinate, $\rho\in (R^{\mathrm{in}}, R^{\mathrm{out}})$ is the radial coordinate, $R^\mathrm{p}> 0$ is the particle radius, $c^{\mathrm{b}}_i\colon (0, T^\mathrm{end})\times (R^\mathrm{in}, R^\mathrm{out}) \mapsto \mathbb{R}$ is the bulk liquid concentration, $Q> 0$ is the volumetric flow rate, $\varepsilon^{\mathrm{c}}\in (0, 1)$ is the column porosity, $v:= \frac{Q}{2 \pi L}$ is the velocity coefficient, $D^\mathrm{rad}_i\geq 0$ is the radial dispersion coefficient, and $k^\mathrm{f}_{i}\geq 0$ is the film diffusion coefficient.
 In the particles, mass transfer is governed by diffusion-reaction equations in $(0, T^\mathrm{end}) \times (R^\mathrm{in}, R^\mathrm{out})\times (0, R^{\mathrm{p}})$ and for all components
 
 \begin{align}

--- a/test/data/ref_latex/Radial_GRM.tex
+++ b/test/data/ref_latex/Radial_GRM.tex
@@ -36,15 +36,15 @@ Specific model assumptions:
 Consider a hollow cylindrical column with inner radius $R^{\mathrm{in}} > 0$ and outer radius $R^{\mathrm{out}} > R^{\mathrm{in}}$ packed with spherical particles, and observed over a time interval $(0, T^{\mathrm{end}})$.
 In the interstitial volume, mass transfer is governed by the following convection-diffusion-reaction equations in $(0, T^\mathrm{end})\times (R^\mathrm{in}, R^\mathrm{out})$ and for all components $i\in\{1, \dots, N^{\mathrm{c}} \}$
 \begin{align}
-\varepsilon^{\mathrm{c}} \frac{\partial c^{\mathrm{b}}_i}{\partial t} = - \frac{v}{\rho} \frac{\partial \left( \varepsilon^{\mathrm{c}} c^{\mathrm{b}}_i \right)}{\partial \rho} + \frac{1}{\rho} \frac{\partial}{\partial \rho} \left( \rho \varepsilon^{\mathrm{c}} D^{\mathrm{ax}}_{i} \frac{\partial c^{\mathrm{b}}_i}{\partial \rho} \right)- \left(1 - \varepsilon^{\mathrm{c}} \right) \frac{3}{R^{\mathrm{p}}} k^{\mathrm{f}}_{i} \left(c^{\mathrm{b}}_i - \left. c^{\mathrm{p}}_{i} \right|_{r = R^{\mathrm{p}}} \right),
+\varepsilon^{\mathrm{c}} \frac{\partial c^{\mathrm{b}}_i}{\partial t} = - \frac{v}{\rho} \frac{\partial \left( \varepsilon^{\mathrm{c}} c^{\mathrm{b}}_i \right)}{\partial \rho} + \frac{1}{\rho} \frac{\partial}{\partial \rho} \left( \rho \varepsilon^{\mathrm{c}} D^{\mathrm{rad}}_{i} \frac{\partial c^{\mathrm{b}}_i}{\partial \rho} \right)- \left(1 - \varepsilon^{\mathrm{c}} \right) \frac{3}{R^{\mathrm{p}}} k^{\mathrm{f}}_{i} \left(c^{\mathrm{b}}_i - \left. c^{\mathrm{p}}_{i} \right|_{r = R^{\mathrm{p}}} \right),
 \end{align}
 with boundary conditions
 
 \begin{alignat}{2}
-v c_{\mathrm{in},i} &= \left.\left( v c^{\mathrm{b}}_i - D^{\mathrm{ax}}_{i} \frac{\partial c^{\mathrm{b}}_i}{\partial \rho}\right)\right|_{\rho=R^{\mathrm{in}}} & &\qquad\text{on }(0, T^{\mathrm{end}}),\\
-               0 &= - D^{\mathrm{ax}}_{i} \left. \frac{\partial c^{\mathrm{b}}_i}{\partial \rho} \right|_{\rho=R^{\mathrm{out}}} & &\qquad\text{on }(0, T^{\mathrm{end}}).
+v c_{\mathrm{in},i} &= \left.\left( v c^{\mathrm{b}}_i - D^{\mathrm{rad}}_{i} \frac{\partial c^{\mathrm{b}}_i}{\partial \rho}\right)\right|_{\rho=R^{\mathrm{in}}} & &\qquad\text{on }(0, T^{\mathrm{end}}),\\
+               0 &= - D^{\mathrm{rad}}_{i} \left. \frac{\partial c^{\mathrm{b}}_i}{\partial \rho} \right|_{\rho=R^{\mathrm{out}}} & &\qquad\text{on }(0, T^{\mathrm{end}}).
 \end{alignat}
-Here, $t\in (0, T^{\mathrm{end}})$ is the time coordinate, $\rho\in (R^{\mathrm{in}}, R^{\mathrm{out}})$ is the radial coordinate, $R^\mathrm{p}> 0$ is the particle radius, $c^{\mathrm{b}}_i\colon (0, T^\mathrm{end})\times (R^\mathrm{in}, R^\mathrm{out}) \mapsto \mathbb{R}$ is the bulk liquid concentration, $\varepsilon^{\mathrm{c}}\in (0, 1)$ is the column porosity, $v> 0$ is the velocity coefficient, $v = \frac{Q}{2 \pi L}$, $D^\mathrm{ax}_i\geq 0$ is the axial dispersion coefficient, and $k^\mathrm{f}_{i}\geq 0$ is the film diffusion coefficient.
+Here, $t\in (0, T^{\mathrm{end}})$ is the time coordinate, $\rho\in (R^{\mathrm{in}}, R^{\mathrm{out}})$ is the radial coordinate, $R^\mathrm{p}> 0$ is the particle radius, $c^{\mathrm{b}}_i\colon (0, T^\mathrm{end})\times (R^\mathrm{in}, R^\mathrm{out}) \mapsto \mathbb{R}$ is the bulk liquid concentration, $\varepsilon^{\mathrm{c}}\in (0, 1)$ is the column porosity, $v> 0$ is the velocity coefficient, $v = \frac{Q}{2 \pi L}$, $D^\mathrm{rad}_i\geq 0$ is the radial dispersion coefficient, and $k^\mathrm{f}_{i}\geq 0$ is the film diffusion coefficient.
 In the particles, mass transfer is governed by diffusion-reaction equations in $(0, T^\mathrm{end}) \times (0, L)\times (0, R^{\mathrm{p}})$ and for all components
 
 \begin{align}

--- a/test/data/ref_latex/Radial_GRM.tex
+++ b/test/data/ref_latex/Radial_GRM.tex
@@ -1,0 +1,63 @@
+\documentclass{article}
+
+\usepackage{amssymb,amsmath,mleftright}
+
+\begin{document}
+
+General model assumptions:
+\begin{itemize}
+\item the fluid density and viscosity are constant in time and space (implies incompressibility);
+\item the fluid flow is laminar;
+\item the column is operated under constant conditions (e.g., temperature, flow rate);
+\item the process is isothermal (i.e., there are no thermal effects);
+\item diffusion does not depend on the concentration of the components, viscosity of the fluid, or pressure;
+\item the fluid in the particles is stagnant (i.e., there is no convective flow);
+\item the porous particles are spherical, rigid, and do not move;
+\item the particles are homogeneous and of uniform porosity;
+\item all components access the same particle volume;
+\item the partial molar volumes are the same in mobile and solid phase;
+\item the binding model parameters do not depend on pressure and are constant along the column;
+\item the solvent is not adsorbed;
+\end{itemize}
+
+
+Specific model assumptions:
+\begin{itemize}
+\item the fluid only flows in the radial direction of the column (i.e., there is no flow in the axial and angular direction);
+\item the column is a hollow cylinder with inner radius $R^{\mathrm{in}}$ and outer radius $R^{\mathrm{out}}$;
+\item the particles form a continuum inside the column (i.e., there is interstitial and particle volume at every point in the column);
+\item the column is radially symmetric and homogeneous (i.e., concentration profiles and parameters only depend on the axial position);
+\item the interstitial liquid phase concentration is spatially constant on the outer particle surface;
+\item there is no surface diffusion (i.e. adsorbed molecules are spatially constant);
+\end{itemize}
+
+
+\section*{Radial Flow General Rate Model}
+Consider a hollow cylindrical column with inner radius $R^{\mathrm{in}} > 0$ and outer radius $R^{\mathrm{out}} > R^{\mathrm{in}}$ packed with spherical particles, and observed over a time interval $(0, T^{\mathrm{end}})$.
+In the interstitial volume, mass transfer is governed by the following convection-diffusion-reaction equations in $(0, T^\mathrm{end})\times (R^\mathrm{in}, R^\mathrm{out})$ and for all components $i\in\{1, \dots, N^{\mathrm{c}} \}$
+\begin{align}
+\varepsilon^{\mathrm{c}} \frac{\partial c^{\mathrm{b}}_i}{\partial t} = - \frac{v}{\rho} \frac{\partial \left( \varepsilon^{\mathrm{c}} c^{\mathrm{b}}_i \right)}{\partial \rho} + \frac{1}{\rho} \frac{\partial}{\partial \rho} \left( \rho \varepsilon^{\mathrm{c}} D^{\mathrm{ax}}_{i} \frac{\partial c^{\mathrm{b}}_i}{\partial \rho} \right)- \left(1 - \varepsilon^{\mathrm{c}} \right) \frac{3}{R^{\mathrm{p}}} k^{\mathrm{f}}_{i} \left(c^{\mathrm{b}}_i - \left. c^{\mathrm{p}}_{i} \right|_{r = R^{\mathrm{p}}} \right),
+\end{align}
+with boundary conditions
+
+\begin{alignat}{2}
+v c_{\mathrm{in},i} &= \left.\left( v c^{\mathrm{b}}_i - D^{\mathrm{ax}}_{i} \frac{\partial c^{\mathrm{b}}_i}{\partial \rho}\right)\right|_{\rho=R^{\mathrm{in}}} & &\qquad\text{on }(0, T^{\mathrm{end}}),\\
+               0 &= - D^{\mathrm{ax}}_{i} \left. \frac{\partial c^{\mathrm{b}}_i}{\partial \rho} \right|_{\rho=R^{\mathrm{out}}} & &\qquad\text{on }(0, T^{\mathrm{end}}).
+\end{alignat}
+Here, $t\in (0, T^{\mathrm{end}})$ is the time coordinate, $\rho\in (R^{\mathrm{in}}, R^{\mathrm{out}})$ is the radial coordinate, $R^\mathrm{p}> 0$ is the particle radius, $c^{\mathrm{b}}_i\colon (0, T^\mathrm{end})\times (R^\mathrm{in}, R^\mathrm{out}) \mapsto \mathbb{R}$ is the bulk liquid concentration, $\varepsilon^{\mathrm{c}}\in (0, 1)$ is the column porosity, $v> 0$ is the velocity coefficient, $v = \frac{Q}{2 \pi L}$, $D^\mathrm{ax}_i\geq 0$ is the axial dispersion coefficient, and $k^\mathrm{f}_{i}\geq 0$ is the film diffusion coefficient.
+In the particles, mass transfer is governed by diffusion-reaction equations in $(0, T^\mathrm{end}) \times (0, L)\times (0, R^{\mathrm{p}})$ and for all components
+
+\begin{align}
+\frac{\partial c^{\mathrm{p}}_{i}}{\partial t} &= \frac{1}{r^2} \frac{\partial }{\partial r} \left( r^2 D_{i}^{\mathrm{p}} \frac{\partial c^{\mathrm{p}}_{i}}{\partial r} \right) - \frac{1 - \varepsilon^{\mathrm{p}}}{\varepsilon^{\mathrm{p}}}f^{\mathrm{bind}}_{i}\left( \vec{c}^{\mathrm{p}}, \vec{c}^{\mathrm{s}} \right), \\
+\frac{\partial c^{\mathrm{s}}_{i}}{\partial t} &= f^{\mathrm{bind}}_{i}\left( \vec{c}^{\mathrm{p}}, \vec{c}^{\mathrm{s}} \right),
+\end{align}
+
+with boundary conditions
+\begin{align}
+- \left. \left( D^{\mathrm{p}}_{i} \frac{\partial c^{\mathrm{p}}_{i}}{\partial r} \right) \right|_{r=0}
+&= 0, \\
+\varepsilon^{\mathrm{p}} \left. \left( D^{\mathrm{p}}_{i} \frac{\partial c^{\mathrm{p}}_{i}}{\partial r} \right)\right|_{r = R^{\mathrm{p}}_{}}
+               &= k^{\mathrm{f}}_{i} \left. \left( c^{\mathrm{b}}_i - c^{\mathrm{p}}_{i} \right|_{r = R^{\mathrm{p}}_{}} \right).\end{align}
+Here, $r$ is the radial particle coordinate, $c^{\mathrm{p}}_{i}\colon (0, T^\mathrm{end}) \times (0, L)\times (0, R^{\mathrm{p}}) \mapsto \mathbb{R}$ is the particle liquid concentration, $c^{\mathrm{s}}_{i}\colon (0, T^\mathrm{end}) \times (0, L)\times (0, R^{\mathrm{p}}) \mapsto \mathbb{R}$ is the particle solid concentration, $\varepsilon^{\mathrm{p}}\in (0, 1)$ is the particle porosity, $D^\mathrm{p}_{i}> 0$ is the particle diffusion coefficient, $f^\mathrm{bind}_{i}$ is the adsorption isotherm function, $\vec{c}^\mathrm{p}$ is the particle liquid components vector, and $\vec{c}^\mathrm{s}$ is the particle solid components vector.
+Consistent initial values for all solution variables (concentrations) are defined at $t = 0$.
+\end{document}

--- a/test/data/ref_latex/Radial_LRM.tex
+++ b/test/data/ref_latex/Radial_LRM.tex
@@ -1,0 +1,55 @@
+\documentclass{article}
+
+\usepackage{amssymb,amsmath,mleftright}
+
+\begin{document}
+
+General model assumptions:
+\begin{itemize}
+\item the fluid density and viscosity are constant in time and space (implies incompressibility);
+\item the fluid flow is laminar;
+\item the column is operated under constant conditions (e.g., temperature, flow rate);
+\item the process is isothermal (i.e., there are no thermal effects);
+\item diffusion does not depend on the concentration of the components, viscosity of the fluid, or pressure;
+\item the fluid in the particles is stagnant (i.e., there is no convective flow);
+\item the porous particles are spherical, rigid, and do not move;
+\item the particles are homogeneous and of uniform porosity;
+\item all components access the same particle volume;
+\item the partial molar volumes are the same in mobile and solid phase;
+\item the binding model parameters do not depend on pressure and are constant along the column;
+\item the solvent is not adsorbed;
+\end{itemize}
+
+
+Specific model assumptions:
+\begin{itemize}
+\item the fluid only flows in the radial direction of the column (i.e., there is no flow in the axial and angular direction);
+\item the column is a hollow cylinder with inner radius $R^{\mathrm{in}}$ and outer radius $R^{\mathrm{out}}$;
+\item the particles form a continuum inside the column (i.e., there is interstitial and particle volume at every point in the column);
+\item the column is radially symmetric and homogeneous (i.e., concentration profiles and parameters only depend on the axial position);
+\item the interstitial liquid phase concentration is spatially constant on the outer particle surface;
+\item the pore and surface diffusion are infinitely fast. That is, we assume $D_{i}^{\mathrm{p}} = D_{i}^{\mathrm{s}} = \infty$;
+\item the film around the particles does not limit mass transfer. That is, we assume $k^{\mathrm{f}}_i = \infty$)
+\end{itemize}
+
+
+\section*{Radial Flow Lumped Rate Model without Pores}
+Consider a hollow cylindrical column with inner radius $R^{\mathrm{in}} > 0$ and outer radius $R^{\mathrm{out}} > R^{\mathrm{in}}$ packed with spherical particles, and observed over a time interval $(0, T^{\mathrm{end}})$.
+In the interstitial volume, mass transfer is governed by the following convection-diffusion equations in $(0, T^\mathrm{end})\times (R^\mathrm{in}, R^\mathrm{out})$ and for all components $i\in\{1, \dots, N^{\mathrm{c}} \}$
+\begin{align}
+\frac{\partial c^{\mathrm{b}}_i}{\partial t} + \frac{1 - \varepsilon^{\mathrm{t}}}{\varepsilon^{\mathrm{t}}} \frac{\partial c^{\mathrm{s}}_i}{\partial t} = - \frac{v}{\rho} \frac{\partial c^{\mathrm{b}}_i}{\partial \rho} + \frac{1}{\rho} \frac{\partial}{\partial \rho} \left( \rho \varepsilon^{\mathrm{c}} D^{\mathrm{ax}}_{i} \frac{\partial c^{\mathrm{b}}_i}{\partial \rho} \right),
+\end{align}
+with boundary conditions
+
+\begin{alignat}{2}
+v c_{\mathrm{in},i} &= \left.\left( v c^{\mathrm{b}}_i - D^{\mathrm{ax}}_{i} \frac{\partial c^{\mathrm{b}}_i}{\partial \rho}\right)\right|_{\rho=R^{\mathrm{in}}} & &\qquad\text{on }(0, T^{\mathrm{end}}),\\
+               0 &= - D^{\mathrm{ax}}_{i} \left. \frac{\partial c^{\mathrm{b}}_i}{\partial \rho} \right|_{\rho=R^{\mathrm{out}}} & &\qquad\text{on }(0, T^{\mathrm{end}}).
+\end{alignat}
+Here, $t\in (0, T^{\mathrm{end}})$ is the time coordinate, $\rho\in (R^{\mathrm{in}}, R^{\mathrm{out}})$ is the radial coordinate, $c^{\mathrm{b}}_i\colon (0, T^\mathrm{end})\times (R^\mathrm{in}, R^\mathrm{out}) \mapsto \mathbb{R}$ is the bulk liquid concentration, $\varepsilon^{\mathrm{t}}\in (0, 1)$ is the total porosity, $v> 0$ is the velocity coefficient, $v = \frac{Q}{2 \pi L}$, and $\tilde{D}^\mathrm{ax}_i\geq 0$ is the apparent axial dispersion coefficient.
+In the particles, mass transfer is governed by reaction equations in $(0, T^\mathrm{end}) \times (0, L)$ and for all components
+\begin{align}
+          \frac{\partial c^{\mathrm{s}}_{i}}{\partial t}
+          &= f^{\mathrm{bind}}_{i}\left( \vec{c}^{\mathrm{\ell}}, \vec{c}^{\mathrm{s}} \right), \end{align}
+Here, $c^{\mathrm{s}}_{i}\colon (0, T^\mathrm{end}) \times (0, L) \mapsto \mathbb{R}$ is the particle solid concentration, $f^\mathrm{bind}_{i}$ is the adsorption isotherm function, $\vec{c}^\mathrm{p}$ is the particle liquid components vector, and $\vec{c}^\mathrm{s}$ is the particle solid components vector.
+Consistent initial values for all solution variables (concentrations) are defined at $t = 0$.
+\end{document}

--- a/test/data/ref_latex/Radial_LRM.tex
+++ b/test/data/ref_latex/Radial_LRM.tex
@@ -37,15 +37,15 @@ Specific model assumptions:
 Consider a hollow cylindrical column with inner radius $R^{\mathrm{in}} > 0$ and outer radius $R^{\mathrm{out}} > R^{\mathrm{in}}$ packed with spherical particles, and observed over a time interval $(0, T^{\mathrm{end}})$.
 In the interstitial volume, mass transfer is governed by the following convection-diffusion equations in $(0, T^\mathrm{end})\times (R^\mathrm{in}, R^\mathrm{out})$ and for all components $i\in\{1, \dots, N^{\mathrm{c}} \}$
 \begin{align}
-\frac{\partial c^{\mathrm{b}}_i}{\partial t} + \frac{1 - \varepsilon^{\mathrm{t}}}{\varepsilon^{\mathrm{t}}} \frac{\partial c^{\mathrm{s}}_i}{\partial t} = - \frac{v}{\rho} \frac{\partial c^{\mathrm{b}}_i}{\partial \rho} + \frac{1}{\rho} \frac{\partial}{\partial \rho} \left( \rho \varepsilon^{\mathrm{c}} D^{\mathrm{ax}}_{i} \frac{\partial c^{\mathrm{b}}_i}{\partial \rho} \right),
+\frac{\partial c^{\mathrm{b}}_i}{\partial t} + \frac{1 - \varepsilon^{\mathrm{t}}}{\varepsilon^{\mathrm{t}}} \frac{\partial c^{\mathrm{s}}_i}{\partial t} = - \frac{v}{\rho} \frac{\partial c^{\mathrm{b}}_i}{\partial \rho} + \frac{1}{\rho} \frac{\partial}{\partial \rho} \left( \rho \varepsilon^{\mathrm{c}} D^{\mathrm{rad}}_{i} \frac{\partial c^{\mathrm{b}}_i}{\partial \rho} \right),
 \end{align}
 with boundary conditions
 
 \begin{alignat}{2}
-v c_{\mathrm{in},i} &= \left.\left( v c^{\mathrm{b}}_i - D^{\mathrm{ax}}_{i} \frac{\partial c^{\mathrm{b}}_i}{\partial \rho}\right)\right|_{\rho=R^{\mathrm{in}}} & &\qquad\text{on }(0, T^{\mathrm{end}}),\\
-               0 &= - D^{\mathrm{ax}}_{i} \left. \frac{\partial c^{\mathrm{b}}_i}{\partial \rho} \right|_{\rho=R^{\mathrm{out}}} & &\qquad\text{on }(0, T^{\mathrm{end}}).
+v c_{\mathrm{in},i} &= \left.\left( v c^{\mathrm{b}}_i - D^{\mathrm{rad}}_{i} \frac{\partial c^{\mathrm{b}}_i}{\partial \rho}\right)\right|_{\rho=R^{\mathrm{in}}} & &\qquad\text{on }(0, T^{\mathrm{end}}),\\
+               0 &= - D^{\mathrm{rad}}_{i} \left. \frac{\partial c^{\mathrm{b}}_i}{\partial \rho} \right|_{\rho=R^{\mathrm{out}}} & &\qquad\text{on }(0, T^{\mathrm{end}}).
 \end{alignat}
-Here, $t\in (0, T^{\mathrm{end}})$ is the time coordinate, $\rho\in (R^{\mathrm{in}}, R^{\mathrm{out}})$ is the radial coordinate, $c^{\mathrm{b}}_i\colon (0, T^\mathrm{end})\times (R^\mathrm{in}, R^\mathrm{out}) \mapsto \mathbb{R}$ is the bulk liquid concentration, $\varepsilon^{\mathrm{t}}\in (0, 1)$ is the total porosity, $v> 0$ is the velocity coefficient, $v = \frac{Q}{2 \pi L}$, and $\tilde{D}^\mathrm{ax}_i\geq 0$ is the apparent axial dispersion coefficient.
+Here, $t\in (0, T^{\mathrm{end}})$ is the time coordinate, $\rho\in (R^{\mathrm{in}}, R^{\mathrm{out}})$ is the radial coordinate, $c^{\mathrm{b}}_i\colon (0, T^\mathrm{end})\times (R^\mathrm{in}, R^\mathrm{out}) \mapsto \mathbb{R}$ is the bulk liquid concentration, $\varepsilon^{\mathrm{t}}\in (0, 1)$ is the total porosity, $v> 0$ is the velocity coefficient, $v = \frac{Q}{2 \pi L}$, and $\tilde{D}^\mathrm{rad}_i\geq 0$ is the apparent radial dispersion coefficient.
 In the particles, mass transfer is governed by reaction equations in $(0, T^\mathrm{end}) \times (0, L)$ and for all components
 \begin{align}
           \frac{\partial c^{\mathrm{s}}_{i}}{\partial t}

--- a/test/data/ref_latex/Radial_LRM.tex
+++ b/test/data/ref_latex/Radial_LRM.tex
@@ -46,10 +46,10 @@ v c_{\mathrm{in},i} &= \left.\left( v c^{\mathrm{b}}_i - D^{\mathrm{rad}}_{i} \f
                0 &= - D^{\mathrm{rad}}_{i} \left. \frac{\partial c^{\mathrm{b}}_i}{\partial \rho} \right|_{\rho=R^{\mathrm{out}}} & &\qquad\text{on }(0, T^{\mathrm{end}}).
 \end{alignat}
 Here, $t\in (0, T^{\mathrm{end}})$ is the time coordinate, $\rho\in (R^{\mathrm{in}}, R^{\mathrm{out}})$ is the radial coordinate, $c^{\mathrm{b}}_i\colon (0, T^\mathrm{end})\times (R^\mathrm{in}, R^\mathrm{out}) \mapsto \mathbb{R}$ is the bulk liquid concentration, $\varepsilon^{\mathrm{t}}\in (0, 1)$ is the total porosity, $v> 0$ is the velocity coefficient, $v = \frac{Q}{2 \pi L}$, and $\tilde{D}^\mathrm{rad}_i\geq 0$ is the apparent radial dispersion coefficient.
-In the particles, mass transfer is governed by reaction equations in $(0, T^\mathrm{end}) \times (0, L)$ and for all components
+In the particles, mass transfer is governed by reaction equations in $(0, T^\mathrm{end}) \times (R^\mathrm{in}, R^\mathrm{out})$ and for all components
 \begin{align}
           \frac{\partial c^{\mathrm{s}}_{i}}{\partial t}
           &= f^{\mathrm{bind}}_{i}\left( \vec{c}^{\mathrm{\ell}}, \vec{c}^{\mathrm{s}} \right), \end{align}
-Here, $c^{\mathrm{s}}_{i}\colon (0, T^\mathrm{end}) \times (0, L) \mapsto \mathbb{R}$ is the particle solid concentration, $f^\mathrm{bind}_{i}$ is the adsorption isotherm function, $\vec{c}^\mathrm{p}$ is the particle liquid components vector, and $\vec{c}^\mathrm{s}$ is the particle solid components vector.
+Here, $c^{\mathrm{s}}_{i}\colon (0, T^\mathrm{end}) \times (R^\mathrm{in}, R^\mathrm{out}) \mapsto \mathbb{R}$ is the particle solid concentration, $f^\mathrm{bind}_{i}$ is the adsorption isotherm function, $\vec{c}^\mathrm{p}$ is the particle liquid components vector, and $\vec{c}^\mathrm{s}$ is the particle solid components vector.
 Consistent initial values for all solution variables (concentrations) are defined at $t = 0$.
 \end{document}

--- a/test/data/ref_latex/Radial_LRM.tex
+++ b/test/data/ref_latex/Radial_LRM.tex
@@ -45,7 +45,7 @@ with boundary conditions
 v c_{\mathrm{in},i} &= \left.\left( v c^{\mathrm{b}}_i - D^{\mathrm{rad}}_{i} \frac{\partial c^{\mathrm{b}}_i}{\partial \rho}\right)\right|_{\rho=R^{\mathrm{in}}} & &\qquad\text{on }(0, T^{\mathrm{end}}),\\
                0 &= - D^{\mathrm{rad}}_{i} \left. \frac{\partial c^{\mathrm{b}}_i}{\partial \rho} \right|_{\rho=R^{\mathrm{out}}} & &\qquad\text{on }(0, T^{\mathrm{end}}).
 \end{alignat}
-Here, $t\in (0, T^{\mathrm{end}})$ is the time coordinate, $\rho\in (R^{\mathrm{in}}, R^{\mathrm{out}})$ is the radial coordinate, $c^{\mathrm{b}}_i\colon (0, T^\mathrm{end})\times (R^\mathrm{in}, R^\mathrm{out}) \mapsto \mathbb{R}$ is the bulk liquid concentration, $\varepsilon^{\mathrm{t}}\in (0, 1)$ is the total porosity, $v> 0$ is the velocity coefficient, $v = \frac{Q}{2 \pi L}$, and $\tilde{D}^\mathrm{rad}_i\geq 0$ is the apparent radial dispersion coefficient.
+Here, $t\in (0, T^{\mathrm{end}})$ is the time coordinate, $\rho\in (R^{\mathrm{in}}, R^{\mathrm{out}})$ is the radial coordinate, $c^{\mathrm{b}}_i\colon (0, T^\mathrm{end})\times (R^\mathrm{in}, R^\mathrm{out}) \mapsto \mathbb{R}$ is the bulk liquid concentration, $Q> 0$ is the volumetric flow rate, $\varepsilon^{\mathrm{t}}\in (0, 1)$ is the total porosity, $v:= \frac{Q}{2 \pi L}$ is the velocity coefficient, and $\tilde{D}^\mathrm{rad}_i\geq 0$ is the apparent radial dispersion coefficient.
 In the particles, mass transfer is governed by reaction equations in $(0, T^\mathrm{end}) \times (R^\mathrm{in}, R^\mathrm{out})$ and for all components
 \begin{align}
           \frac{\partial c^{\mathrm{s}}_{i}}{\partial t}

--- a/test/data/ref_latex/Radial_LRMP.tex
+++ b/test/data/ref_latex/Radial_LRMP.tex
@@ -28,11 +28,11 @@ Specific model assumptions:
 \item the particles form a continuum inside the column (i.e., there is interstitial and particle volume at every point in the column);
 \item the column is radially symmetric and homogeneous (i.e., concentration profiles and parameters only depend on the axial position);
 \item the interstitial liquid phase concentration is spatially constant on the outer particle surface;
-\item there is no surface diffusion (i.e. adsorbed molecules are spatially constant);
+\item the pore and surface diffusion are infinitely fast. That is, we assume $D_{i}^{\mathrm{p}} = D_{i}^{\mathrm{s}} = \infty$;
 \end{itemize}
 
 
-\section*{Radial Flow General Rate Model}
+\section*{Radial Flow Lumped Rate Model with Pores}
 Consider a hollow cylindrical column with inner radius $R^{\mathrm{in}} > 0$ and outer radius $R^{\mathrm{out}} > R^{\mathrm{in}}$ packed with spherical particles, and observed over a time interval $(0, T^{\mathrm{end}})$.
 In the interstitial volume, mass transfer is governed by the following convection-diffusion-reaction equations in $(0, T^\mathrm{end})\times (R^\mathrm{in}, R^\mathrm{out})$ and for all components $i\in\{1, \dots, N^{\mathrm{c}} \}$
 \begin{align}
@@ -45,19 +45,17 @@ v c_{\mathrm{in},i} &= \left.\left( v c^{\mathrm{b}}_i - D^{\mathrm{rad}}_{i} \f
                0 &= - D^{\mathrm{rad}}_{i} \left. \frac{\partial c^{\mathrm{b}}_i}{\partial \rho} \right|_{\rho=R^{\mathrm{out}}} & &\qquad\text{on }(0, T^{\mathrm{end}}).
 \end{alignat}
 Here, $t\in (0, T^{\mathrm{end}})$ is the time coordinate, $\rho\in (R^{\mathrm{in}}, R^{\mathrm{out}})$ is the radial coordinate, $R^\mathrm{p}> 0$ is the particle radius, $c^{\mathrm{b}}_i\colon (0, T^\mathrm{end})\times (R^\mathrm{in}, R^\mathrm{out}) \mapsto \mathbb{R}$ is the bulk liquid concentration, $\varepsilon^{\mathrm{c}}\in (0, 1)$ is the column porosity, $v> 0$ is the velocity coefficient, $v = \frac{Q}{2 \pi L}$, $D^\mathrm{rad}_i\geq 0$ is the radial dispersion coefficient, and $k^\mathrm{f}_{i}\geq 0$ is the film diffusion coefficient.
-In the particles, mass transfer is governed by diffusion-reaction equations in $(0, T^\mathrm{end}) \times (R^\mathrm{in}, R^\mathrm{out})\times (0, R^{\mathrm{p}})$ and for all components
+In the particles, mass transfer is governed by reaction equations in $(0, T^\mathrm{end}) \times (R^\mathrm{in}, R^\mathrm{out})$ and for all components
 
 \begin{align}
-\frac{\partial c^{\mathrm{p}}_{i}}{\partial t} &= \frac{1}{r^2} \frac{\partial }{\partial r} \left( r^2 D_{i}^{\mathrm{p}} \frac{\partial c^{\mathrm{p}}_{i}}{\partial r} \right) - \frac{1 - \varepsilon^{\mathrm{p}}}{\varepsilon^{\mathrm{p}}}f^{\mathrm{bind}}_{i}\left( \vec{c}^{\mathrm{p}}, \vec{c}^{\mathrm{s}} \right), \\
-\frac{\partial c^{\mathrm{s}}_{i}}{\partial t} &= f^{\mathrm{bind}}_{i}\left( \vec{c}^{\mathrm{p}}, \vec{c}^{\mathrm{s}} \right),
+
+          \varepsilon^{\mathrm{p}}\frac{\partial c^{\mathrm{p}}_{i}}{\partial t} 
+          &=\frac{3}{R^{\mathrm{p}}} k^\mathrm{f}_{i} \left( c^{\mathrm{b}}_{i} - c^{\mathrm{p}}_{i} \right) - \left( 1 - \varepsilon^{\mathrm{p}} \right) f^{\mathrm{bind}}_{i}\left( \vec{c}^{\mathrm{p}}, \vec{c}^{\mathrm{s}} \right),\\
+
+          \frac{\partial c^{\mathrm{s}}_{i}}{\partial t}
+          &= f^{\mathrm{bind}}_{i}\left( \vec{c}^{\mathrm{p}}, \vec{c}^{\mathrm{s}} \right).
 \end{align}
 
-with boundary conditions
-\begin{align}
-- \left. \left( D^{\mathrm{p}}_{i} \frac{\partial c^{\mathrm{p}}_{i}}{\partial r} \right) \right|_{r=0}
-&= 0, \\
-\varepsilon^{\mathrm{p}} \left. \left( D^{\mathrm{p}}_{i} \frac{\partial c^{\mathrm{p}}_{i}}{\partial r} \right)\right|_{r = R^{\mathrm{p}}_{}}
-               &= k^{\mathrm{f}}_{i} \left. \left( c^{\mathrm{b}}_i - c^{\mathrm{p}}_{i} \right|_{r = R^{\mathrm{p}}_{}} \right).\end{align}
-Here, $r$ is the radial particle coordinate, $c^{\mathrm{p}}_{i}\colon (0, T^\mathrm{end}) \times (R^\mathrm{in}, R^\mathrm{out})\times (0, R^{\mathrm{p}}) \mapsto \mathbb{R}$ is the particle liquid concentration, $c^{\mathrm{s}}_{i}\colon (0, T^\mathrm{end}) \times (R^\mathrm{in}, R^\mathrm{out})\times (0, R^{\mathrm{p}}) \mapsto \mathbb{R}$ is the particle solid concentration, $\varepsilon^{\mathrm{p}}\in (0, 1)$ is the particle porosity, $D^\mathrm{p}_{i}> 0$ is the particle diffusion coefficient, $f^\mathrm{bind}_{i}$ is the adsorption isotherm function, $\vec{c}^\mathrm{p}$ is the particle liquid components vector, and $\vec{c}^\mathrm{s}$ is the particle solid components vector.
+Here, $c^{\mathrm{p}}_{i}\colon (0, T^\mathrm{end}) \times (R^\mathrm{in}, R^\mathrm{out}) \mapsto \mathbb{R}$ is the particle liquid concentration, $c^{\mathrm{s}}_{i}\colon (0, T^\mathrm{end}) \times (R^\mathrm{in}, R^\mathrm{out}) \mapsto \mathbb{R}$ is the particle solid concentration, $f^\mathrm{bind}_{i}$ is the adsorption isotherm function, $\vec{c}^\mathrm{p}$ is the particle liquid components vector, and $\vec{c}^\mathrm{s}$ is the particle solid components vector.
 Consistent initial values for all solution variables (concentrations) are defined at $t = 0$.
 \end{document}

--- a/test/data/ref_latex/Radial_LRMP.tex
+++ b/test/data/ref_latex/Radial_LRMP.tex
@@ -44,7 +44,7 @@ with boundary conditions
 v c_{\mathrm{in},i} &= \left.\left( v c^{\mathrm{b}}_i - D^{\mathrm{rad}}_{i} \frac{\partial c^{\mathrm{b}}_i}{\partial \rho}\right)\right|_{\rho=R^{\mathrm{in}}} & &\qquad\text{on }(0, T^{\mathrm{end}}),\\
                0 &= - D^{\mathrm{rad}}_{i} \left. \frac{\partial c^{\mathrm{b}}_i}{\partial \rho} \right|_{\rho=R^{\mathrm{out}}} & &\qquad\text{on }(0, T^{\mathrm{end}}).
 \end{alignat}
-Here, $t\in (0, T^{\mathrm{end}})$ is the time coordinate, $\rho\in (R^{\mathrm{in}}, R^{\mathrm{out}})$ is the radial coordinate, $R^\mathrm{p}> 0$ is the particle radius, $c^{\mathrm{b}}_i\colon (0, T^\mathrm{end})\times (R^\mathrm{in}, R^\mathrm{out}) \mapsto \mathbb{R}$ is the bulk liquid concentration, $\varepsilon^{\mathrm{c}}\in (0, 1)$ is the column porosity, $v> 0$ is the velocity coefficient, $v = \frac{Q}{2 \pi L}$, $D^\mathrm{rad}_i\geq 0$ is the radial dispersion coefficient, and $k^\mathrm{f}_{i}\geq 0$ is the film diffusion coefficient.
+Here, $t\in (0, T^{\mathrm{end}})$ is the time coordinate, $\rho\in (R^{\mathrm{in}}, R^{\mathrm{out}})$ is the radial coordinate, $R^\mathrm{p}> 0$ is the particle radius, $c^{\mathrm{b}}_i\colon (0, T^\mathrm{end})\times (R^\mathrm{in}, R^\mathrm{out}) \mapsto \mathbb{R}$ is the bulk liquid concentration, $Q> 0$ is the volumetric flow rate, $\varepsilon^{\mathrm{c}}\in (0, 1)$ is the column porosity, $v:= \frac{Q}{2 \pi L}$ is the velocity coefficient, $D^\mathrm{rad}_i\geq 0$ is the radial dispersion coefficient, and $k^\mathrm{f}_{i}\geq 0$ is the film diffusion coefficient.
 In the particles, mass transfer is governed by reaction equations in $(0, T^\mathrm{end}) \times (R^\mathrm{in}, R^\mathrm{out})$ and for all components
 
 \begin{align}

--- a/test/data/ref_latex/Radial_Plug_Flow.tex
+++ b/test/data/ref_latex/Radial_Plug_Flow.tex
@@ -1,0 +1,39 @@
+\documentclass{article}
+
+\usepackage{amssymb,amsmath,mleftright}
+
+\begin{document}
+
+General model assumptions:
+\begin{itemize}
+\item the fluid density and viscosity are constant in time and space (implies incompressibility);
+\item the fluid flow is laminar;
+\item the column is operated under constant conditions (e.g., temperature, flow rate);
+\item the process is isothermal (i.e., there are no thermal effects);
+\item diffusion does not depend on the concentration of the components, viscosity of the fluid, or pressure;
+\item there is no solid phase in the column (and thus no adsorption);
+\end{itemize}
+
+
+Specific model assumptions:
+\begin{itemize}
+\item the fluid only flows in the radial direction of the column (i.e., there is no flow in the axial and angular direction);
+\item the column is a hollow cylinder with inner radius $R^{\mathrm{in}}$ and outer radius $R^{\mathrm{out}}$;
+\item the column is radially symmetric and homogeneous (i.e., concentration profiles and parameters only depend on the axial position);
+\end{itemize}
+
+
+\section*{Radial Plug Flow}
+Consider a hollow cylindrical column with inner radius $R^{\mathrm{in}} > 0$ and outer radius $R^{\mathrm{out}} > R^{\mathrm{in}}$ filled with a liquid phase, and observed over a time interval $(0, T^{\mathrm{end}})$.
+In the interstitial volume, mass transfer is governed by the following convection equations in $(0, T^\mathrm{end})\times (R^\mathrm{in}, R^\mathrm{out})$ and for all components $i\in\{1, \dots, N^{\mathrm{c}} \}$
+\begin{align}
+\varepsilon^{\mathrm{c}} \frac{\partial c^{\mathrm{b}}_i}{\partial t} = - \frac{v}{\rho} \frac{\partial \left( \varepsilon^{\mathrm{c}} c^{\mathrm{b}}_i \right)}{\partial \rho},
+\end{align}
+with boundary conditions
+
+\begin{alignat}{2}
+v c_{\mathrm{in},i} &= \left.\left( v c^{\mathrm{b}}_i \right)\right|_{\rho=R^{\mathrm{in}}} & &\qquad\text{on }(0, T^{\mathrm{end}}).
+\end{alignat}
+Here, $t\in (0, T^{\mathrm{end}})$ is the time coordinate, $\rho\in (R^{\mathrm{in}}, R^{\mathrm{out}})$ is the radial coordinate, $c^{\mathrm{b}}_i\colon (0, T^\mathrm{end})\times (R^\mathrm{in}, R^\mathrm{out}) \mapsto \mathbb{R}$ is the bulk liquid concentration, and $v> 0$ is the velocity coefficient, $v = \frac{Q}{2 \pi L}$.
+Consistent initial values for all solution variables (concentrations) are defined at $t = 0$.
+\end{document}

--- a/test/data/ref_latex/Radial_Plug_Flow.tex
+++ b/test/data/ref_latex/Radial_Plug_Flow.tex
@@ -34,6 +34,6 @@ with boundary conditions
 \begin{alignat}{2}
 v c_{\mathrm{in},i} &= \left.\left( v c^{\mathrm{b}}_i \right)\right|_{\rho=R^{\mathrm{in}}} & &\qquad\text{on }(0, T^{\mathrm{end}}).
 \end{alignat}
-Here, $t\in (0, T^{\mathrm{end}})$ is the time coordinate, $\rho\in (R^{\mathrm{in}}, R^{\mathrm{out}})$ is the radial coordinate, $c^{\mathrm{b}}_i\colon (0, T^\mathrm{end})\times (R^\mathrm{in}, R^\mathrm{out}) \mapsto \mathbb{R}$ is the bulk liquid concentration, and $v> 0$ is the velocity coefficient, $v = \frac{Q}{2 \pi L}$.
+Here, $t\in (0, T^{\mathrm{end}})$ is the time coordinate, $\rho\in (R^{\mathrm{in}}, R^{\mathrm{out}})$ is the radial coordinate, $c^{\mathrm{b}}_i\colon (0, T^\mathrm{end})\times (R^\mathrm{in}, R^\mathrm{out}) \mapsto \mathbb{R}$ is the bulk liquid concentration, $Q> 0$ is the volumetric flow rate, and $v:= \frac{Q}{2 \pi L}$ is the velocity coefficient.
 Consistent initial values for all solution variables (concentrations) are defined at $t = 0$.
 \end{document}

--- a/test/test_refLatex.py
+++ b/test/test_refLatex.py
@@ -42,7 +42,7 @@ def apply_model_from_config(at, model_config):
 
 @pytest.mark.ci
 @pytest.mark.reference
-@pytest.mark.parametrize("model_name", ["CSTR", "Plug_Flow", "LRM", "LRMP", "GRMsd", "GRM", "GRMsd_PSD", "GRMsd2D", "GRMsd_nonLimFD_parCore", "GRMsd_nonLimFD_reqBnd", "GeneralFiniteBath"])
+@pytest.mark.parametrize("model_name", ["CSTR", "Plug_Flow", "LRM", "LRMP", "GRMsd", "GRM", "GRMsd_PSD", "GRMsd2D", "GRMsd_nonLimFD_parCore", "GRMsd_nonLimFD_reqBnd", "GeneralFiniteBath", "Radial_Plug_Flow", "Radial_Dispersive_Plug_Flow", "Radial_GRM", "Radial_LRM", "Frustum_Plug_Flow", "Frustum_GRM"])
 def test_json_config_output_against_latex_reference(model_name, test_dir):
 
     at = AppTest.from_file("../Equation-Generator.py")

--- a/test/test_refLatex.py
+++ b/test/test_refLatex.py
@@ -42,7 +42,7 @@ def apply_model_from_config(at, model_config):
 
 @pytest.mark.ci
 @pytest.mark.reference
-@pytest.mark.parametrize("model_name", ["CSTR", "Plug_Flow", "LRM", "LRMP", "GRMsd", "GRM", "GRMsd_PSD", "GRMsd2D", "GRMsd_nonLimFD_parCore", "GRMsd_nonLimFD_reqBnd", "GeneralFiniteBath", "Radial_Plug_Flow", "Radial_Dispersive_Plug_Flow", "Radial_GRM", "Radial_LRM", "Frustum_Plug_Flow", "Frustum_GRM"])
+@pytest.mark.parametrize("model_name", ["CSTR", "Plug_Flow", "LRM", "LRMP", "GRMsd", "GRM", "GRMsd_PSD", "GRMsd2D", "GRMsd_nonLimFD_parCore", "GRMsd_nonLimFD_reqBnd", "GeneralFiniteBath", "Radial_Plug_Flow", "Radial_Dispersive_Plug_Flow", "Radial_GRM", "Radial_LRM", "Radial_LRMP", "Frustum_Plug_Flow", "Frustum_GRM"])
 def test_json_config_output_against_latex_reference(model_name, test_dir):
 
     at = AppTest.from_file("../Equation-Generator.py")

--- a/test/test_ui.py
+++ b/test/test_ui.py
@@ -13,7 +13,7 @@ untested_variables = ["dev_mode", "advanced_mode", "var_format", "sym_table", "s
 # We thus first identify the boxes that change the number of boxes and thus combinations (critical_variables).
 # We then start the recursion for every combination of the aforementioned critical keys.
 # Sometimes, only specific options can be critical (e.g. 0D tank). Such options can be added here and handled independently later
-critical_variables = untested_variables + ["add_particles", "has_binding", "particle_resolution", "0D (Homogeneous Tank)"]
+critical_variables = untested_variables + ["add_particles", "has_binding", "particle_resolution", "0D (Homogeneous Tank)", "column_type"]
 
 # We test every configuration by recursively iteratiing through all combinations
 def config_recursion(at, widgies, counter, test_file_generator_buttons:bool):


### PR DESCRIPTION
## Summary
- Adds two new column geometry types for 1D models: **Radial flow** (hollow cylinder with transport in the radial direction) and conical **Frustum**
- Implements geometry-specific convection/dispersion equations, boundary conditions, domain definitions, model assumptions, and parameter tables
- Adds UI selectbox for column geometry selection (available for 1D resolution)

Closes #57