### PR TITLE
Add per-component film diffusion and surface diffusion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,6 @@ jobs:
       run: |
         conda run -n cadet-equations pytest -m "ci and (unit_test or reference)" \
           --cov=src \
-          --cov=Equation-Generator.py \
           --cov-report=xml:coverage.xml \
           --cov-report=term-missing
 

--- a/Equation-Generator.py
+++ b/Equation-Generator.py
@@ -290,7 +290,8 @@ if column_model.N_p > 0:
 
             for par_type in column_model.par_type_counts.keys():
 
-                if not column_model.has_binding and group['nonlimiting_filmDiff'] and par_type.resolution == "0D":
+                orig_idx = column_model._original_partype_indices[par_type][0] - 1
+                if not column_model.has_binding and group['nonlimiting_filmDiff_per_partype'][orig_idx] and par_type.resolution == "0D":
                     break
 
                 if dev_mode_:
@@ -369,7 +370,7 @@ if column_model.N_p > 0:
 
                     # The salt component is in rapid equilibrium binding mode
                     salt_group = dict(group)
-                    salt_group['req_binding'] = True
+                    salt_group['req_binding_per_partype'] = [True] * len(group['req_binding_per_partype'])
                     tmpBndModel = column_model.binding_model
                     column_model.binding_model = "SMA_salt"
                     particle_eq_salt, particle_bc_salt = column_model.particle_equations_for_group(salt_group)

--- a/Equation-Generator.py
+++ b/Equation-Generator.py
@@ -241,17 +241,39 @@ if column_model.resolution == "0D":
         r"The evolution of the liquid volume $V^{\l}\colon (0, T^{\mathrm{end}}) \to \mathbb{R}$ and the concentrations $c_i\colon (0, T^{\mathrm{end}}) \to \mathbb{R}$ of the components in the tank is governed by")
     write_and_save(interstitial_volume_eq, as_latex=True)
 else:
-    eq_type = "convection" # first order derivative
-    if not column_model.resolution == "1D" or column_model.has_axial_dispersion: # second order derivative
-        eq_type += "-diffusion"
-    if column_model.N_p > 0 and not column_model.nonlimiting_filmDiff: # i.e. film diffusion term (reaction type)
-        eq_type += "-reaction"
+    component_groups_intV = column_model.component_groups()
+    if column_model.interstitial_groups_differ_in_film_diff(component_groups_intV):
+        # Per-component mode: film diffusion settings differ, show separate bulk equations per group
+        for group in component_groups_intV:
+            nlf = group['nonlimiting_filmDiff_per_partype'][0]
+            comp_set_str = column_model.format_component_set(group['components'])
 
-    write_and_save(r"In the interstitial volume, mass transfer is governed by the following " + eq_type +
-                   " equations in " + column_model.domain_interstitial() + r" and for all components " + nComp_list)
-    write_and_save(interstitial_volume_eq, as_latex=True)
-    write_and_save("with boundary conditions")
-    write_and_save(column_model.interstitial_volume_bc(), as_latex=True)
+            eq_type = "convection"
+            if not column_model.resolution == "1D" or column_model.has_axial_dispersion:
+                eq_type += "-diffusion"
+            if column_model.N_p > 0 and not nlf:
+                eq_type += "-reaction"
+
+            write_and_save(
+                "For component(s) " + comp_set_str +
+                r", in the interstitial volume, mass transfer is governed by the following " + eq_type +
+                " equations in " + column_model.domain_interstitial())
+            write_and_save(column_model.interstitial_volume_equation_for_group(group), as_latex=True)
+
+        write_and_save("with boundary conditions")
+        write_and_save(column_model.interstitial_volume_bc(), as_latex=True)
+    else:
+        eq_type = "convection" # first order derivative
+        if not column_model.resolution == "1D" or column_model.has_axial_dispersion: # second order derivative
+            eq_type += "-diffusion"
+        if column_model.N_p > 0 and not column_model.nonlimiting_filmDiff: # i.e. film diffusion term (reaction type)
+            eq_type += "-reaction"
+
+        write_and_save(r"In the interstitial volume, mass transfer is governed by the following " + eq_type +
+                       " equations in " + column_model.domain_interstitial() + r" and for all components " + nComp_list)
+        write_and_save(interstitial_volume_eq, as_latex=True)
+        write_and_save("with boundary conditions")
+        write_and_save(column_model.interstitial_volume_bc(), as_latex=True)
 
 if show_eq_description:
     write_and_save("Here, " + column_model.vars_params_description())

--- a/Equation-Generator.py
+++ b/Equation-Generator.py
@@ -108,7 +108,7 @@ var_format_ = st.sidebar.selectbox("Select parameter format", [
 advanced_mode_ = st.sidebar.selectbox("Advanced options (enables e.g. particle size distribution)", [
                                       "Off", "On"], key=r"advanced_mode") == "On"
 if advanced_mode_:
-    dev_mode_ = st.sidebar.selectbox("Developer options (not tested! Enables e.g. particle type distribution)", [
+    dev_mode_ = st.sidebar.selectbox("Developer options (not tested! Enables e.g. particle type distribution, per-component configuration)", [
                                      "Off", "On"], key=r"dev_mode") == "On"
     if dev_mode_:
         advanced_mode_ = True

--- a/codecov.yml
+++ b/codecov.yml
@@ -9,6 +9,9 @@ coverage:
         target: auto
         threshold: 1%
 
+ignore:
+  - "Equation-Generator.py"  # Streamlit entry point, not importable as a module for coverage
+
 comment:
   layout: "reach,diff,flags,components"
   behavior: default

--- a/src/model_column.py
+++ b/src/model_column.py
@@ -606,9 +606,20 @@ class Column:
             
         self.vars_and_params = sorted(self.vars_and_params, key=lambda x: x['Group'])
 
-    def interstitial_volume_equation(self):
+    def interstitial_volume_equation(self, nlf_override=None, sd_override=None):
+        """Generate the interstitial volume equation.
 
-        without_pores_ = self.nonlimiting_filmDiff and self.has_binding and self.particle_models[0].resolution == "0D"       
+        Parameters
+        ----------
+        nlf_override : bool, optional
+            Override for nonlimiting_filmDiff (used for per-component groups).
+        sd_override : bool, optional
+            Override for has_surfDiff (used for per-component groups).
+        """
+        nlf = nlf_override if nlf_override is not None else self.nonlimiting_filmDiff
+        sd = sd_override if sd_override is not None else self.has_surfDiff
+
+        without_pores_ = nlf and self.has_binding and self.particle_models[0].resolution == "0D"
 
         if self.resolution == "0D":
 
@@ -619,14 +630,14 @@ class Column:
     \\
     \frac{\mathrm{d}}{\mathrm{d} t} \left( V^{\b} c^{\b}_i \right)"""
 
-            if self.nonlimiting_filmDiff and self.has_binding and self.particle_models[0].resolution == "0D":
+            if nlf and self.has_binding and self.particle_models[0].resolution == "0D":
                 equation += r" + V^{\p} \varepsilon^{\mathrm{p}} \frac{\partial c^{b}_i}{\partial t}"
                 if self.req_binding:
                     equation += r" + V^{\p} \left( 1 - \varepsilon^{\mathrm{p}} \right) \frac{\partial c^{\s}_i}{\partial t}"
 
             equation += r"&= Q_{\mathrm{in}} c^{\b}_{\mathrm{in},i} - Q_{\mathrm{out}} c^{\b}_i"
 
-            if self.nonlimiting_filmDiff and self.has_binding and self.particle_models[0].resolution == "0D" and not self.req_binding:
+            if nlf and self.has_binding and self.particle_models[0].resolution == "0D" and not self.req_binding:
                 equation += r" - V^{\p} \left( 1 - \varepsilon^{\mathrm{p}} \right) \frac{\partial c^{\s}_i}{\partial t}"
 
             if self.has_reaction_bulk and not self.req_reaction_bulk:
@@ -664,25 +675,35 @@ class Column:
                 equation = re.sub(r"\\varepsilon^{\\mathrm{c}}", "", re.sub(
                     r"\\left\( \\varepsilon^{\\mathrm{c}} c^{\\l}_i \\right\)", r"c^{\\l}_i", equation))
 
-        par_added = 0
-        for par_uniq in self.par_unique_intV_contribution_counts.keys():
+        if nlf_override is not None:
+            # Per-component group: single particle type (N_p == 1)
+            equation += eq.int_filmDiff_term(
+                Particle(
+                    self.particle_models[0].geometry, self.particle_models[0].has_core,
+                    self.var_format, self.particle_models[0].resolution
+                ),
+                1, 1, True, nlf, sd
+            )
+        else:
+            par_added = 0
+            for par_uniq in self.par_unique_intV_contribution_counts.keys():
 
-            if self.dev_mode:
-                equation += eq.int_filmDiff_term(
-                    Particle(
-                        self.particle_models[par_added].geometry, self.particle_models[par_added].has_core, self.var_format, self.particle_models[par_added].resolution
-                    ),
-                    1 + par_added, par_added + self.par_unique_intV_contribution_counts[par_uniq], self.N_p == 1, self.particle_models[par_added].nonlimiting_filmDiff, self.particle_models[par_added].has_surfDiff
-                )
-            else:
-                equation += eq.int_filmDiff_term(
-                    Particle(
-                        self.particle_models[0].geometry, self.particle_models[0].has_core, self.var_format, self.particle_models[0].resolution
-                    ),
-                    1, r"N^{\mathrm{p}}", self.N_p == 1, self.particle_models[0].nonlimiting_filmDiff, self.particle_models[0].has_surfDiff
-                )
+                if self.dev_mode:
+                    equation += eq.int_filmDiff_term(
+                        Particle(
+                            self.particle_models[par_added].geometry, self.particle_models[par_added].has_core, self.var_format, self.particle_models[par_added].resolution
+                        ),
+                        1 + par_added, par_added + self.par_unique_intV_contribution_counts[par_uniq], self.N_p == 1, self.particle_models[par_added].nonlimiting_filmDiff, self.particle_models[par_added].has_surfDiff
+                    )
+                else:
+                    equation += eq.int_filmDiff_term(
+                        Particle(
+                            self.particle_models[0].geometry, self.particle_models[0].has_core, self.var_format, self.particle_models[0].resolution
+                        ),
+                        1, r"N^{\mathrm{p}}", self.N_p == 1, self.particle_models[0].nonlimiting_filmDiff, self.particle_models[0].has_surfDiff
+                    )
 
-            par_added += self.par_unique_intV_contribution_counts[par_uniq]
+                par_added += self.par_unique_intV_contribution_counts[par_uniq]
 
         if self.has_reaction_bulk and not self.req_reaction_bulk and self.resolution != "0D":
             equation += " + " + eq.bulk_reaction_term()
@@ -704,60 +725,10 @@ class Column:
             return None
 
     def interstitial_volume_equation_for_group(self, group):
-        """Generate the interstitial volume equation for a specific component group.
-
-        Uses the group's film diffusion and surface diffusion settings instead of
-        the global settings. Only valid when N_p == 1 (per-component and per-particle
-        are mutually exclusive).
-        """
+        """Generate the interstitial volume equation for a specific component group."""
         nlf = group['nonlimiting_filmDiff_per_partype'][0]
         sd = group['has_surfDiff_per_partype'][0]
-
-        without_pores_ = nlf and self.has_binding and self.particle_models[0].resolution == "0D"
-
-        equation = eq.bulk_time_derivative(r"\varepsilon^{\mathrm{c}}") if not without_pores_ else eq.bulk_time_derivative()
-        if without_pores_:
-            equation += r" + " + eq.solid_time_derivative(r"\varepsilon^{\mathrm{t}}")
-
-        needs_linebreak = self.has_radial_dispersion or self.has_angular_dispersion
-        eq_sign = " &= " if needs_linebreak else " = "
-
-        if self.column_type == "Radial":
-            convection_func = eq.radial_flow_convection
-            dispersion_func = eq.radial_flow_dispersion
-        elif self.column_type == "Frustum":
-            convection_func = eq.frustum_convection
-            dispersion_func = eq.frustum_dispersion
-        else:
-            convection_func = eq.axial_convection
-            dispersion_func = eq.axial_dispersion
-
-        equation += eq_sign + convection_func() if without_pores_ else eq_sign + convection_func(r"\varepsilon^{\mathrm{c}}")
-
-        if self.has_axial_dispersion:
-            equation += " + " + dispersion_func(r"\varepsilon^{\mathrm{c}}")
-        if self.has_radial_dispersion:
-            equation += r" \nonumber \\ & + " + eq.radial_dispersion(r"\varepsilon^{\mathrm{c}}")
-        if self.has_angular_dispersion:
-            equation += r" \nonumber \\ & + " + eq.angular_dispersion(r"\varepsilon^{\mathrm{c}}")
-
-        # Single particle type (N_p == 1 guaranteed when N_c > 0)
-        equation += eq.int_filmDiff_term(
-            Particle(
-                self.particle_models[0].geometry, self.particle_models[0].has_core,
-                self.var_format, self.particle_models[0].resolution
-            ),
-            1, 1, True, nlf, sd
-        )
-
-        if self.has_reaction_bulk and not self.req_reaction_bulk:
-            equation += " + " + eq.bulk_reaction_term()
-
-        equation = r"""\begin{align}
-""" + equation + r""",
-\end{align}"""
-
-        return equation
+        return self.interstitial_volume_equation(nlf_override=nlf, sd_override=sd)
 
     def interstitial_groups_differ_in_film_diff(self, component_groups):
         """Check if component groups have different film diffusion settings relevant to interstitial eq."""

--- a/src/model_column.py
+++ b/src/model_column.py
@@ -427,9 +427,10 @@ class Column:
         for comp_i in range(self.N_c):
             st.write(f"**Component {comp_i + 1}**")
             comp_film.append(
-                st.selectbox("Film diffusion",
-                             ["Limiting", "Non-limiting"],
-                             key=f"parType_{j}_filmDiff_comp_{comp_i}") == "Non-limiting"
+                st.selectbox("Infinite film diffusion rate",
+                             ["No", "Yes"],
+                             key=f"parType_{j}_filmDiff_comp_{comp_i}") == "Yes"
+                
             )
             if self.has_binding and par_resolution == "1D":
                 comp_surf.append(

--- a/src/model_column.py
+++ b/src/model_column.py
@@ -162,44 +162,25 @@ class Column:
                 self.has_binding = st.selectbox(
                     "Add binding", ["No", "Yes"], key=r"has_binding") == "Yes"
 
+                if self.N_c > 0:
+                    self.nonlimiting_filmDiff_per_comp = []
+                    self.has_surfDiff_per_comp = []
+
                 if self.dev_mode and self.N_p > 1:
                     # Dev mode (PTD): per-particle-type config
                     for j in range(self.N_p):
                         with st.expander(f"Particle type {j + 1}"):
                             particle_configs.append(self.configure_particle_type(typeCounter=j))
+                            if self.N_c > 0:
+                                self._collect_per_component_transport(j, particle_configs[j]['resolution'])
                 else:
                     # Single particle or PSD in advanced mode: shared config
                     shared_config = self.configure_particle_type(typeCounter=-1)
                     particle_configs = [shared_config.copy() for _ in range(self.N_p)]
+                    if self.N_c > 0:
+                        self._collect_per_component_transport(0, shared_config['resolution'])
 
-                # Per-component transport configuration (film/surface diffusion)
                 if self.N_c > 0:
-                    self.nonlimiting_filmDiff_per_comp = []
-                    self.has_surfDiff_per_comp = []
-                    resolution = particle_configs[0]['resolution'] if particle_configs else "1D"
-                    for j in range(self.N_p):
-                        par_resolution = particle_configs[j]['resolution'] if len(particle_configs) > j else "1D"
-                        comp_film = []
-                        comp_surf = []
-                        label = f"Particle type {j + 1}: per-component transport" if self.N_p > 1 else "Per-component transport"
-                        with st.expander(label):
-                            for comp_i in range(self.N_c):
-                                st.write(f"**Component {comp_i + 1}**")
-                                comp_film.append(
-                                    st.selectbox("Film diffusion",
-                                                 ["Limiting", "Non-limiting"],
-                                                 key=f"parType_{j}_filmDiff_comp_{comp_i}") == "Non-limiting"
-                                )
-                                if self.has_binding and par_resolution == "1D":
-                                    comp_surf.append(
-                                        st.selectbox("Surface diffusion",
-                                                     ["No", "Yes"],
-                                                     key=f"parType_{j}_surfDiff_comp_{comp_i}") == "Yes"
-                                    )
-                                else:
-                                    comp_surf.append(False)
-                        self.nonlimiting_filmDiff_per_comp.append(comp_film)
-                        self.has_surfDiff_per_comp.append(comp_surf)
                     # Set global fallback for code paths that use it
                     self.nonlimiting_filmDiff = all(
                         all(row) for row in self.nonlimiting_filmDiff_per_comp)
@@ -438,6 +419,28 @@ class Column:
         }
 
         return config
+
+    def _collect_per_component_transport(self, j, par_resolution):
+        """Collect per-component film/surface diffusion UI within a particle type context."""
+        comp_film = []
+        comp_surf = []
+        for comp_i in range(self.N_c):
+            st.write(f"**Component {comp_i + 1}**")
+            comp_film.append(
+                st.selectbox("Film diffusion",
+                             ["Limiting", "Non-limiting"],
+                             key=f"parType_{j}_filmDiff_comp_{comp_i}") == "Non-limiting"
+            )
+            if self.has_binding and par_resolution == "1D":
+                comp_surf.append(
+                    st.selectbox("Surface diffusion",
+                                 ["No", "Yes"],
+                                 key=f"parType_{j}_surfDiff_comp_{comp_i}") == "Yes"
+                )
+            else:
+                comp_surf.append(False)
+        self.nonlimiting_filmDiff_per_comp.append(comp_film)
+        self.has_surfDiff_per_comp.append(comp_surf)
 
     def available_CADET_Core(self):
         """

--- a/src/model_column.py
+++ b/src/model_column.py
@@ -155,6 +155,12 @@ class Column:
             else:
                 self.N_p = int(st.selectbox("Add particles", ["No", "Yes"], key=r"add_particles") == "Yes")
 
+            # Per-particle-type and per-component are mutually exclusive
+            if self.N_p > 1 and self.N_c > 0:
+                st.info("Per-component and per-particle-type configuration are mutually exclusive. "
+                        "Per-component configuration is disabled when multiple particle types are specified.")
+                self.N_c = -1
+
             # Collect per-particle-type transport configs
             particle_configs = []
 
@@ -171,8 +177,6 @@ class Column:
                     for j in range(self.N_p):
                         with st.expander(f"Particle type {j + 1}"):
                             particle_configs.append(self.configure_particle_type(typeCounter=j))
-                            if self.N_c > 0:
-                                self._collect_per_component_transport(j, particle_configs[j]['resolution'])
                 else:
                     # Single particle or PSD in advanced mode: shared config
                     shared_config = self.configure_particle_type(typeCounter=-1)
@@ -205,35 +209,6 @@ class Column:
                                 'req_binding': req_bnd_j,
                                 'has_mult_bnd_states': mult_bnd_j,
                             })
-                elif self.dev_mode and self.N_p > 1 and self.N_c > 0:
-                    # Per-component within per-particle-type (most granular)
-                    self._binding_per_partype = []
-                    self.req_binding_per_comp = []
-                    self.has_mult_bnd_states_per_comp = []
-                    for j in range(self.N_p):
-                        with st.expander(f"Particle type {j + 1}"):
-                            bnd_model_j = st.selectbox("Binding model", eq.BINDING_MODELS, key=f"parType_{j+1}_binding_model")
-                            comp_req = []
-                            comp_mbs = []
-                            for comp_i in range(self.N_c):
-                                st.write(f"**Component {comp_i + 1}**")
-                                comp_req.append(
-                                    st.selectbox("Binding kinetics mode",
-                                                 ["Kinetic", "Rapid-equilibrium"],
-                                                 key=f"parType_{j}_req_binding_comp_{comp_i}") == "Rapid-equilibrium"
-                                )
-                                comp_mbs.append(
-                                    st.selectbox("Multiple bound states",
-                                                 ["No", "Yes"],
-                                                 key=f"parType_{j}_has_mult_bnd_states_comp_{comp_i}") == "Yes"
-                                )
-                            self._binding_per_partype.append({
-                                'binding_model': bnd_model_j,
-                                'req_binding': any(comp_req),
-                                'has_mult_bnd_states': any(comp_mbs),
-                            })
-                            self.req_binding_per_comp.append(comp_req)
-                            self.has_mult_bnd_states_per_comp.append(comp_mbs)
                 else:
                     if self.N_c <= 0:
                         self.req_binding = st.selectbox("Binding kinetics mode", [
@@ -727,6 +702,73 @@ class Column:
             return eq.int_vol_BC(self.resolution, self.has_axial_dispersion, self.column_type)
         else:
             return None
+
+    def interstitial_volume_equation_for_group(self, group):
+        """Generate the interstitial volume equation for a specific component group.
+
+        Uses the group's film diffusion and surface diffusion settings instead of
+        the global settings. Only valid when N_p == 1 (per-component and per-particle
+        are mutually exclusive).
+        """
+        nlf = group['nonlimiting_filmDiff_per_partype'][0]
+        sd = group['has_surfDiff_per_partype'][0]
+
+        without_pores_ = nlf and self.has_binding and self.particle_models[0].resolution == "0D"
+
+        equation = eq.bulk_time_derivative(r"\varepsilon^{\mathrm{c}}") if not without_pores_ else eq.bulk_time_derivative()
+        if without_pores_:
+            equation += r" + " + eq.solid_time_derivative(r"\varepsilon^{\mathrm{t}}")
+
+        needs_linebreak = self.has_radial_dispersion or self.has_angular_dispersion
+        eq_sign = " &= " if needs_linebreak else " = "
+
+        if self.column_type == "Radial":
+            convection_func = eq.radial_flow_convection
+            dispersion_func = eq.radial_flow_dispersion
+        elif self.column_type == "Frustum":
+            convection_func = eq.frustum_convection
+            dispersion_func = eq.frustum_dispersion
+        else:
+            convection_func = eq.axial_convection
+            dispersion_func = eq.axial_dispersion
+
+        equation += eq_sign + convection_func() if without_pores_ else eq_sign + convection_func(r"\varepsilon^{\mathrm{c}}")
+
+        if self.has_axial_dispersion:
+            equation += " + " + dispersion_func(r"\varepsilon^{\mathrm{c}}")
+        if self.has_radial_dispersion:
+            equation += r" \nonumber \\ & + " + eq.radial_dispersion(r"\varepsilon^{\mathrm{c}}")
+        if self.has_angular_dispersion:
+            equation += r" \nonumber \\ & + " + eq.angular_dispersion(r"\varepsilon^{\mathrm{c}}")
+
+        # Single particle type (N_p == 1 guaranteed when N_c > 0)
+        equation += eq.int_filmDiff_term(
+            Particle(
+                self.particle_models[0].geometry, self.particle_models[0].has_core,
+                self.var_format, self.particle_models[0].resolution
+            ),
+            1, 1, True, nlf, sd
+        )
+
+        if self.has_reaction_bulk and not self.req_reaction_bulk:
+            equation += " + " + eq.bulk_reaction_term()
+
+        equation = r"""\begin{align}
+""" + equation + r""",
+\end{align}"""
+
+        return equation
+
+    def interstitial_groups_differ_in_film_diff(self, component_groups):
+        """Check if component groups have different film diffusion settings relevant to interstitial eq."""
+        if component_groups is None or len(component_groups) <= 1:
+            return False
+        first_key = (component_groups[0]['nonlimiting_filmDiff_per_partype'][0],
+                     component_groups[0]['has_surfDiff_per_partype'][0])
+        return any(
+            (g['nonlimiting_filmDiff_per_partype'][0], g['has_surfDiff_per_partype'][0]) != first_key
+            for g in component_groups[1:]
+        )
 
     def particle_equations(self):
 

--- a/src/model_column.py
+++ b/src/model_column.py
@@ -119,9 +119,9 @@ class Column:
             self.has_angular_coordinate = True
             self.has_angular_dispersion = True
 
-        if self.advanced_mode:
+        if self.dev_mode:
             n_c_choice = st.sidebar.selectbox(
-                "Number of components (enables per-component configuration)",
+                "Number of components (per-component configuration)",
                 ["Arbitrary"] + list(range(1, 11)),
                 key=r"N_c_choice")
             self.N_c = -1 if n_c_choice == "Arbitrary" else int(n_c_choice)

--- a/src/model_column.py
+++ b/src/model_column.py
@@ -182,7 +182,8 @@ class Column:
                     shared_config = self.configure_particle_type(typeCounter=-1)
                     particle_configs = [shared_config.copy() for _ in range(self.N_p)]
                     if self.N_c > 0:
-                        self._collect_per_component_transport(0, shared_config['resolution'])
+                        with st.expander("Per-component transport"):
+                            self._collect_per_component_transport(0, shared_config['resolution'])
 
                 if self.N_c > 0:
                     # Set global fallback for code paths that use it
@@ -222,18 +223,19 @@ class Column:
                     if self.N_c > 0:
                         self.req_binding_per_comp = [[]]
                         self.has_mult_bnd_states_per_comp = [[]]
-                        for comp_i in range(self.N_c):
-                            st.write(f"**Component {comp_i + 1}**")
-                            self.req_binding_per_comp[0].append(
-                                st.selectbox("Binding kinetics mode",
-                                             ["Kinetic", "Rapid-equilibrium"],
-                                             key=f"req_binding_comp_{comp_i}") == "Rapid-equilibrium"
-                            )
-                            self.has_mult_bnd_states_per_comp[0].append(
-                                st.selectbox("Multiple bound states",
-                                             ["No", "Yes"],
-                                             key=f"has_mult_bnd_states_comp_{comp_i}") == "Yes"
-                            )
+                        with st.expander("Per-component binding"):
+                            for comp_i in range(self.N_c):
+                                st.write(f"**Component {comp_i + 1}**")
+                                self.req_binding_per_comp[0].append(
+                                    st.selectbox("Binding kinetics mode",
+                                                 ["Kinetic", "Rapid-equilibrium"],
+                                                 key=f"req_binding_comp_{comp_i}") == "Rapid-equilibrium"
+                                )
+                                self.has_mult_bnd_states_per_comp[0].append(
+                                    st.selectbox("Multiple bound states",
+                                                 ["No", "Yes"],
+                                                 key=f"has_mult_bnd_states_comp_{comp_i}") == "Yes"
+                                )
 
         # Initialize per-component binding lists when binding is disabled
         if self.N_p > 0 and self.N_c > 0 and not self.has_binding:

--- a/src/model_column.py
+++ b/src/model_column.py
@@ -40,11 +40,12 @@ class Column:
 
     nonlimiting_filmDiff: bool = False
 
-    # Per-component configuration (used in dev_mode when N_c > 0)
-    req_binding_per_comp: Optional[List[bool]] = None
-    nonlimiting_filmDiff_per_comp: Optional[List[bool]] = None
-    has_surfDiff_per_comp: Optional[List[bool]] = None
-    has_mult_bnd_states_per_comp: Optional[List[bool]] = None
+    # Per-component configuration (used when N_c > 0)
+    # All indexed as [partype][comp]
+    req_binding_per_comp: Optional[List[List[bool]]] = None
+    nonlimiting_filmDiff_per_comp: Optional[List[List[bool]]] = None
+    has_surfDiff_per_comp: Optional[List[List[bool]]] = None
+    has_mult_bnd_states_per_comp: Optional[List[List[bool]]] = None
 
     # Per-particle-type configuration (used when N_p > 1 and N_c <= 0)
     nonlimiting_filmDiff_per_partype: Optional[List[bool]] = None
@@ -118,7 +119,7 @@ class Column:
             self.has_angular_coordinate = True
             self.has_angular_dispersion = True
 
-        if self.dev_mode:
+        if self.advanced_mode:
             n_c_choice = st.sidebar.selectbox(
                 "Number of components (enables per-component configuration)",
                 ["Arbitrary"] + list(range(1, 11)),
@@ -171,11 +172,45 @@ class Column:
                     shared_config = self.configure_particle_type(typeCounter=-1)
                     particle_configs = [shared_config.copy() for _ in range(self.N_p)]
 
+                # Per-component transport configuration (film/surface diffusion)
+                if self.N_c > 0:
+                    self.nonlimiting_filmDiff_per_comp = []
+                    self.has_surfDiff_per_comp = []
+                    resolution = particle_configs[0]['resolution'] if particle_configs else "1D"
+                    for j in range(self.N_p):
+                        par_resolution = particle_configs[j]['resolution'] if len(particle_configs) > j else "1D"
+                        comp_film = []
+                        comp_surf = []
+                        label = f"Particle type {j + 1}: per-component transport" if self.N_p > 1 else "Per-component transport"
+                        with st.expander(label):
+                            for comp_i in range(self.N_c):
+                                st.write(f"**Component {comp_i + 1}**")
+                                comp_film.append(
+                                    st.selectbox("Film diffusion",
+                                                 ["Limiting", "Non-limiting"],
+                                                 key=f"parType_{j}_filmDiff_comp_{comp_i}") == "Non-limiting"
+                                )
+                                if self.has_binding and par_resolution == "1D":
+                                    comp_surf.append(
+                                        st.selectbox("Surface diffusion",
+                                                     ["No", "Yes"],
+                                                     key=f"parType_{j}_surfDiff_comp_{comp_i}") == "Yes"
+                                    )
+                                else:
+                                    comp_surf.append(False)
+                        self.nonlimiting_filmDiff_per_comp.append(comp_film)
+                        self.has_surfDiff_per_comp.append(comp_surf)
+                    # Set global fallback for code paths that use it
+                    self.nonlimiting_filmDiff = all(
+                        all(row) for row in self.nonlimiting_filmDiff_per_comp)
+                    self.has_surfDiff = any(
+                        any(row) for row in self.has_surfDiff_per_comp)
+
         # Configure binding model (separate section)
         if self.N_p > 0 and self.has_binding:
             with st.sidebar.expander("Configure binding", expanded=True):
                 if self.dev_mode and self.N_p > 1 and self.N_c <= 0:
-                    # Per-particle-type binding config
+                    # Per-particle-type binding config (no per-component)
                     self._binding_per_partype = []
                     for j in range(self.N_p):
                         with st.expander(f"Particle type {j + 1}"):
@@ -189,6 +224,35 @@ class Column:
                                 'req_binding': req_bnd_j,
                                 'has_mult_bnd_states': mult_bnd_j,
                             })
+                elif self.dev_mode and self.N_p > 1 and self.N_c > 0:
+                    # Per-component within per-particle-type (most granular)
+                    self._binding_per_partype = []
+                    self.req_binding_per_comp = []
+                    self.has_mult_bnd_states_per_comp = []
+                    for j in range(self.N_p):
+                        with st.expander(f"Particle type {j + 1}"):
+                            bnd_model_j = st.selectbox("Binding model", eq.BINDING_MODELS, key=f"parType_{j+1}_binding_model")
+                            comp_req = []
+                            comp_mbs = []
+                            for comp_i in range(self.N_c):
+                                st.write(f"**Component {comp_i + 1}**")
+                                comp_req.append(
+                                    st.selectbox("Binding kinetics mode",
+                                                 ["Kinetic", "Rapid-equilibrium"],
+                                                 key=f"parType_{j}_req_binding_comp_{comp_i}") == "Rapid-equilibrium"
+                                )
+                                comp_mbs.append(
+                                    st.selectbox("Multiple bound states",
+                                                 ["No", "Yes"],
+                                                 key=f"parType_{j}_has_mult_bnd_states_comp_{comp_i}") == "Yes"
+                                )
+                            self._binding_per_partype.append({
+                                'binding_model': bnd_model_j,
+                                'req_binding': any(comp_req),
+                                'has_mult_bnd_states': any(comp_mbs),
+                            })
+                            self.req_binding_per_comp.append(comp_req)
+                            self.has_mult_bnd_states_per_comp.append(comp_mbs)
                 else:
                     if self.N_c <= 0:
                         self.req_binding = st.selectbox("Binding kinetics mode", [
@@ -198,32 +262,27 @@ class Column:
                         self.has_mult_bnd_states = st.selectbox("Add multiple bound states", [
                                                                         "No", "Yes"], key=r"has_mult_bnd_states") == "Yes" if self.advanced_mode else False
 
-                # Per-component configuration
-                if self.dev_mode and self.N_c > 0:
-                    st.write("Per-component configuration")
-                    self.req_binding_per_comp = []
-                    self.nonlimiting_filmDiff_per_comp = []
-                    self.has_surfDiff_per_comp = []
-                    self.has_mult_bnd_states_per_comp = []
-                    for comp_i in range(self.N_c):
-                        with st.expander(f"Component {comp_i + 1}"):
-                            self.nonlimiting_filmDiff_per_comp.append(self.nonlimiting_filmDiff)
-                            if self.has_binding:
-                                self.req_binding_per_comp.append(
-                                    st.selectbox("Binding kinetics mode",
-                                                 ["Kinetic", "Rapid-equilibrium"],
-                                                 key=f"req_binding_comp_{comp_i}") == "Rapid-equilibrium"
-                                )
-                                self.has_surfDiff_per_comp.append(self.has_surfDiff)
-                                self.has_mult_bnd_states_per_comp.append(
-                                    st.selectbox("Multiple bound states",
-                                                 ["No", "Yes"],
-                                                 key=f"has_mult_bnd_states_comp_{comp_i}") == "Yes"
-                                )
-                            else:
-                                self.req_binding_per_comp.append(False)
-                                self.has_surfDiff_per_comp.append(False)
-                                self.has_mult_bnd_states_per_comp.append(False)
+                    # Per-component binding (single particle type)
+                    if self.N_c > 0:
+                        self.req_binding_per_comp = [[]]
+                        self.has_mult_bnd_states_per_comp = [[]]
+                        for comp_i in range(self.N_c):
+                            st.write(f"**Component {comp_i + 1}**")
+                            self.req_binding_per_comp[0].append(
+                                st.selectbox("Binding kinetics mode",
+                                             ["Kinetic", "Rapid-equilibrium"],
+                                             key=f"req_binding_comp_{comp_i}") == "Rapid-equilibrium"
+                            )
+                            self.has_mult_bnd_states_per_comp[0].append(
+                                st.selectbox("Multiple bound states",
+                                             ["No", "Yes"],
+                                             key=f"has_mult_bnd_states_comp_{comp_i}") == "Yes"
+                            )
+
+        # Initialize per-component binding lists when binding is disabled
+        if self.N_p > 0 and self.N_c > 0 and not self.has_binding:
+            self.req_binding_per_comp = [[False] * self.N_c for _ in range(self.N_p)]
+            self.has_mult_bnd_states_per_comp = [[False] * self.N_c for _ in range(self.N_p)]
 
         # Merge per-particle-type binding settings into particle configs
         if self.N_p > 0 and hasattr(self, '_binding_per_partype'):
@@ -269,8 +328,13 @@ class Column:
                 self._original_partype_indices.setdefault(p, []).append(j + 1)
 
             # Sort and count particle types
-            self.particle_models = sorted(self.particle_models, key=lambda particle: (
-                particle.geometry, particle.resolution, particle.nonlimiting_filmDiff, particle.has_surfDiff))
+            # When N_c > 0, transport is per-component so don't sort by transport fields
+            if self.N_c > 0:
+                self.particle_models = sorted(self.particle_models, key=lambda particle: (
+                    particle.geometry, particle.resolution))
+            else:
+                self.particle_models = sorted(self.particle_models, key=lambda particle: (
+                    particle.geometry, particle.resolution, particle.nonlimiting_filmDiff, particle.has_surfDiff))
             self.par_type_counts = Counter(self.particle_models)
             if self.nonlimiting_filmDiff:
                 self.par_unique_intV_contribution_counts = Counter(
@@ -350,16 +414,20 @@ class Column:
         else:
             geometry = "Sphere"
 
-        nonlimiting_filmDiff_j = st.selectbox(
-            "Infinite film diffusion rate", ["No", "Yes"], key=transportPrefix + "nonlimiting_filmDiff") == "Yes"
-        self.nonlimiting_filmDiff = nonlimiting_filmDiff_j
+        if self.N_c <= 0:
+            nonlimiting_filmDiff_j = st.selectbox(
+                "Infinite film diffusion rate", ["No", "Yes"], key=transportPrefix + "nonlimiting_filmDiff") == "Yes"
+            self.nonlimiting_filmDiff = nonlimiting_filmDiff_j
 
-        has_surfDiff_j = False
-        if self.has_binding and resolution == "1D":
-            has_surfDiff_j = st.selectbox(
-                "Add surface diffusion", ["No", "Yes"],
-                key=transportPrefix + "has_surfDiff") == "Yes"
-            self.has_surfDiff = has_surfDiff_j
+            has_surfDiff_j = False
+            if self.has_binding and resolution == "1D":
+                has_surfDiff_j = st.selectbox(
+                    "Add surface diffusion", ["No", "Yes"],
+                    key=transportPrefix + "has_surfDiff") == "Yes"
+                self.has_surfDiff = has_surfDiff_j
+        else:
+            nonlimiting_filmDiff_j = False
+            has_surfDiff_j = False
 
         config = {
             'geometry': geometry,
@@ -713,29 +781,32 @@ class Column:
 
         Returns a list of dicts, each containing:
           - 'components': list of 1-based component indices
-          - 'req_binding', 'nonlimiting_filmDiff', 'has_surfDiff', 'has_mult_bnd_states': the shared settings
+          - per-partype settings: 'nonlimiting_filmDiff_per_partype', 'has_surfDiff_per_partype',
+            'req_binding_per_partype', 'has_mult_bnd_states_per_partype'
         """
         if not self.has_per_component_config():
             return None
 
         groups = {}
         for i in range(self.N_c):
-            key = (
-                self.req_binding_per_comp[i],
-                self.nonlimiting_filmDiff_per_comp[i],
-                self.has_surfDiff_per_comp[i],
-                self.has_mult_bnd_states_per_comp[i],
+            # Key includes all per-partype settings for this component
+            per_partype_key = tuple(
+                (self.nonlimiting_filmDiff_per_comp[j][i],
+                 self.has_surfDiff_per_comp[j][i],
+                 self.req_binding_per_comp[j][i],
+                 self.has_mult_bnd_states_per_comp[j][i])
+                for j in range(self.N_p)
             )
-            groups.setdefault(key, []).append(i + 1)  # 1-based index
+            groups.setdefault(per_partype_key, []).append(i + 1)  # 1-based index
 
         result = []
-        for (req_b, nlf, sd, mbs), comps in groups.items():
+        for per_partype, comps in groups.items():
             result.append({
                 'components': comps,
-                'req_binding': req_b,
-                'nonlimiting_filmDiff': nlf,
-                'has_surfDiff': sd,
-                'has_mult_bnd_states': mbs,
+                'nonlimiting_filmDiff_per_partype': [t[0] for t in per_partype],
+                'has_surfDiff_per_partype': [t[1] for t in per_partype],
+                'req_binding_per_partype': [t[2] for t in per_partype],
+                'has_mult_bnd_states_per_partype': [t[3] for t in per_partype],
             })
         return result
 
@@ -744,26 +815,36 @@ class Column:
         eqs = {}
         boundary_conditions = {}
 
-        for par_type in self.par_type_counts.keys():
+        for idx, par_type in enumerate(self.par_type_counts.keys()):
+            # Get per-partype transport from group (indexed by original partype order)
+            # Use the first original index for this unique particle type
+            orig_idx = self._original_partype_indices[par_type][0] - 1  # convert 1-based to 0-based
+            nlf = group['nonlimiting_filmDiff_per_partype'][orig_idx]
+            sd = group['has_surfDiff_per_partype'][orig_idx]
+
+            req_b = group['req_binding_per_partype'][orig_idx]
+            mbs = group['has_mult_bnd_states_per_partype'][orig_idx]
+
+            bnd_model = par_type.binding_model if self.N_p > 1 else self.binding_model
 
             eqs[par_type] = eq.particle_transport(
                 par_type, singleParticle=self.N_p == 1,
-                nonlimiting_filmDiff=group['nonlimiting_filmDiff'],
-                has_surfDiff=group['has_surfDiff'],
+                nonlimiting_filmDiff=nlf,
+                has_surfDiff=sd,
                 has_binding=self.has_binding,
-                req_binding=group['req_binding'],
-                has_mult_bnd_states=group['has_mult_bnd_states'],
+                req_binding=req_b,
+                has_mult_bnd_states=mbs,
                 has_reaction_liquid=self.has_reaction_particle_liquid,
                 has_reaction_solid=self.has_reaction_particle_solid,
-                binding_model=self.binding_model)
+                binding_model=bnd_model)
 
             boundary_conditions[par_type] = eq.particle_boundary(
                 par_type, singleParticle=self.N_p == 1,
-                nonlimiting_filmDiff=group['nonlimiting_filmDiff'],
-                has_surfDiff=group['has_surfDiff'],
+                nonlimiting_filmDiff=nlf,
+                has_surfDiff=sd,
                 has_binding=self.has_binding,
-                req_binding=group['req_binding'],
-                has_mult_bnd_states=group['has_mult_bnd_states'])
+                req_binding=req_b,
+                has_mult_bnd_states=mbs)
 
             if self.N_p == 1:
                 eqs[par_type] = re.sub(",j", "", eqs[par_type])

--- a/src/model_column.py
+++ b/src/model_column.py
@@ -157,7 +157,7 @@ class Column:
 
             # Per-particle-type and per-component are mutually exclusive
             if self.N_p > 1 and self.N_c > 0:
-                st.info("Per-component and per-particle-type configuration are mutually exclusive. "
+                st.warning("Per-component and per-particle-type configuration are mutually exclusive. "
                         "Per-component configuration is disabled when multiple particle types are specified.")
                 self.N_c = -1
 

--- a/test/test_per_component.py
+++ b/test/test_per_component.py
@@ -8,7 +8,7 @@ from streamlit.testing.v1 import AppTest
 import pytest
 
 
-def setup_grm_with_per_component(at, n_comp, per_comp_settings):
+def setup_grm_with_per_component(at, n_comp, per_comp_settings, n_p=1, use_dev_mode=False):
     """Set up a GRM model with per-component configuration.
 
     Parameters
@@ -20,14 +20,33 @@ def setup_grm_with_per_component(at, n_comp, per_comp_settings):
     per_comp_settings : list of dict
         Per-component settings, each dict with keys:
         'req_binding', 'nonlimiting_filmDiff', 'has_surfDiff', 'has_mult_bnd_states'
+    n_p : int
+        Number of particle types (default 1).
+    use_dev_mode : bool
+        Whether to enable dev_mode (needed for N_p > 1).
     """
     at.selectbox(key="advanced_mode").set_value("On").run()
-    at.selectbox(key="dev_mode").set_value("On").run()
+    if use_dev_mode:
+        at.selectbox(key="dev_mode").set_value("On").run()
     at.selectbox(key="N_c_choice").set_value(n_comp).run()
-    at.number_input(key=r"N^\mathrm{p}").set_value(1).run()
+
+    if use_dev_mode:
+        at.number_input(key=r"N^\mathrm{p}").set_value(n_p).run()
+    else:
+        at.selectbox(key="PSD").set_value("Yes").run()
+
     at.selectbox(key="particle_resolution").set_value("1D (radial coordinate)").run()
     at.selectbox(key="has_binding").set_value("Yes").run()
 
+    # Set per-component transport in particle panel (parType_0 for single particle type)
+    for i, settings in enumerate(per_comp_settings):
+        film_diff = "Non-limiting" if settings.get('nonlimiting_filmDiff', False) else "Limiting"
+        at.selectbox(key=f"parType_0_filmDiff_comp_{i}").set_value(film_diff).run()
+        if settings.get('has_surfDiff', False) is not False:
+            surf_diff = "Yes" if settings['has_surfDiff'] else "No"
+            at.selectbox(key=f"parType_0_surfDiff_comp_{i}").set_value(surf_diff).run()
+
+    # Set per-component binding in binding panel
     for i, settings in enumerate(per_comp_settings):
         at.selectbox(key=f"req_binding_comp_{i}").set_value(settings['req_binding']).run()
         at.selectbox(key=f"has_mult_bnd_states_comp_{i}").set_value(settings['has_mult_bnd_states']).run()
@@ -42,8 +61,8 @@ def test_per_component_uniform_settings():
     assert not at.exception
 
     settings = [
-        {'req_binding': 'Kinetic', 'nonlimiting_filmDiff': 'No', 'has_surfDiff': 'Yes', 'has_mult_bnd_states': 'No'},
-        {'req_binding': 'Kinetic', 'nonlimiting_filmDiff': 'No', 'has_surfDiff': 'Yes', 'has_mult_bnd_states': 'No'},
+        {'req_binding': 'Kinetic', 'nonlimiting_filmDiff': False, 'has_surfDiff': True, 'has_mult_bnd_states': 'No'},
+        {'req_binding': 'Kinetic', 'nonlimiting_filmDiff': False, 'has_surfDiff': True, 'has_mult_bnd_states': 'No'},
     ]
     setup_grm_with_per_component(at, 2, settings)
 
@@ -63,8 +82,8 @@ def test_per_component_different_binding_kinetics():
     assert not at.exception
 
     settings = [
-        {'req_binding': 'Kinetic', 'nonlimiting_filmDiff': 'No', 'has_surfDiff': 'No', 'has_mult_bnd_states': 'No'},
-        {'req_binding': 'Rapid-equilibrium', 'nonlimiting_filmDiff': 'No', 'has_surfDiff': 'No', 'has_mult_bnd_states': 'No'},
+        {'req_binding': 'Kinetic', 'nonlimiting_filmDiff': False, 'has_surfDiff': False, 'has_mult_bnd_states': 'No'},
+        {'req_binding': 'Rapid-equilibrium', 'nonlimiting_filmDiff': False, 'has_surfDiff': False, 'has_mult_bnd_states': 'No'},
     ]
     setup_grm_with_per_component(at, 2, settings)
 
@@ -85,9 +104,9 @@ def test_per_component_three_components_two_groups():
     assert not at.exception
 
     settings = [
-        {'req_binding': 'Kinetic', 'nonlimiting_filmDiff': 'No', 'has_surfDiff': 'No', 'has_mult_bnd_states': 'No'},
-        {'req_binding': 'Rapid-equilibrium', 'nonlimiting_filmDiff': 'No', 'has_surfDiff': 'No', 'has_mult_bnd_states': 'No'},
-        {'req_binding': 'Kinetic', 'nonlimiting_filmDiff': 'No', 'has_surfDiff': 'No', 'has_mult_bnd_states': 'No'},
+        {'req_binding': 'Kinetic', 'nonlimiting_filmDiff': False, 'has_surfDiff': False, 'has_mult_bnd_states': 'No'},
+        {'req_binding': 'Rapid-equilibrium', 'nonlimiting_filmDiff': False, 'has_surfDiff': False, 'has_mult_bnd_states': 'No'},
+        {'req_binding': 'Kinetic', 'nonlimiting_filmDiff': False, 'has_surfDiff': False, 'has_mult_bnd_states': 'No'},
     ]
     setup_grm_with_per_component(at, 3, settings)
 
@@ -109,8 +128,8 @@ def test_per_component_different_mult_bnd_states():
     assert not at.exception
 
     settings = [
-        {'req_binding': 'Kinetic', 'nonlimiting_filmDiff': 'No', 'has_surfDiff': 'No', 'has_mult_bnd_states': 'Yes'},
-        {'req_binding': 'Kinetic', 'nonlimiting_filmDiff': 'No', 'has_surfDiff': 'No', 'has_mult_bnd_states': 'No'},
+        {'req_binding': 'Kinetic', 'nonlimiting_filmDiff': False, 'has_surfDiff': False, 'has_mult_bnd_states': 'Yes'},
+        {'req_binding': 'Kinetic', 'nonlimiting_filmDiff': False, 'has_surfDiff': False, 'has_mult_bnd_states': 'No'},
     ]
     setup_grm_with_per_component(at, 2, settings)
 
@@ -128,20 +147,166 @@ def test_per_component_0d_particle_resolution():
     assert not at.exception
 
     at.selectbox(key="advanced_mode").set_value("On").run()
-    at.selectbox(key="dev_mode").set_value("On").run()
     at.selectbox(key="N_c_choice").set_value(2).run()
-    at.number_input(key=r"N^\mathrm{p}").set_value(1).run()
+    at.selectbox(key="PSD").set_value("Yes").run()
     at.selectbox(key="particle_resolution").set_value("0D (homogeneous)").run()
     at.selectbox(key="has_binding").set_value("Yes").run()
 
-    at.selectbox(key=f"req_binding_comp_0").set_value("Kinetic").run()
-    at.selectbox(key=f"has_mult_bnd_states_comp_0").set_value("No").run()
+    # Film diffusion per component (parType_0 for single particle)
+    at.selectbox(key="parType_0_filmDiff_comp_0").set_value("Limiting").run()
+    at.selectbox(key="parType_0_filmDiff_comp_1").set_value("Limiting").run()
 
-    at.selectbox(key=f"req_binding_comp_1").set_value("Rapid-equilibrium").run()
-    at.selectbox(key=f"has_mult_bnd_states_comp_1").set_value("No").run()
+    # Binding per component
+    at.selectbox(key="req_binding_comp_0").set_value("Kinetic").run()
+    at.selectbox(key="has_mult_bnd_states_comp_0").set_value("No").run()
+    at.selectbox(key="req_binding_comp_1").set_value("Rapid-equilibrium").run()
+    at.selectbox(key="has_mult_bnd_states_comp_1").set_value("No").run()
 
     assert not at.exception
     latex = at.session_state.latex_string
+    assert "For component(s)" in latex
+
+
+@pytest.mark.ci
+@pytest.mark.reference
+def test_per_component_different_film_diffusion():
+    """Test per-component with mixed film diffusion settings."""
+    at = AppTest.from_file("../Equation-Generator.py")
+    at.run()
+    assert not at.exception
+
+    settings = [
+        {'req_binding': 'Kinetic', 'nonlimiting_filmDiff': True, 'has_surfDiff': False, 'has_mult_bnd_states': 'No'},
+        {'req_binding': 'Kinetic', 'nonlimiting_filmDiff': False, 'has_surfDiff': False, 'has_mult_bnd_states': 'No'},
+    ]
+    setup_grm_with_per_component(at, 2, settings)
+
+    assert not at.exception
+    latex = at.session_state.latex_string
+    assert "For component(s)" in latex
+    assert r"i = 1" in latex
+    assert r"i = 2" in latex
+
+
+@pytest.mark.ci
+@pytest.mark.reference
+def test_per_component_different_surface_diffusion():
+    """Test per-component with mixed surface diffusion settings."""
+    at = AppTest.from_file("../Equation-Generator.py")
+    at.run()
+    assert not at.exception
+
+    settings = [
+        {'req_binding': 'Kinetic', 'nonlimiting_filmDiff': False, 'has_surfDiff': True, 'has_mult_bnd_states': 'No'},
+        {'req_binding': 'Kinetic', 'nonlimiting_filmDiff': False, 'has_surfDiff': False, 'has_mult_bnd_states': 'No'},
+    ]
+    setup_grm_with_per_component(at, 2, settings)
+
+    assert not at.exception
+    latex = at.session_state.latex_string
+    assert "For component(s)" in latex
+    assert r"i = 1" in latex
+    assert r"i = 2" in latex
+
+
+@pytest.mark.ci
+@pytest.mark.reference
+def test_per_component_no_binding_film_diffusion():
+    """Test per-component film diffusion without binding enabled."""
+    at = AppTest.from_file("../Equation-Generator.py")
+    at.run()
+    assert not at.exception
+
+    at.selectbox(key="advanced_mode").set_value("On").run()
+    at.selectbox(key="N_c_choice").set_value(2).run()
+    at.selectbox(key="PSD").set_value("Yes").run()
+    at.selectbox(key="particle_resolution").set_value("1D (radial coordinate)").run()
+    at.selectbox(key="has_binding").set_value("No").run()
+
+    at.selectbox(key="parType_0_filmDiff_comp_0").set_value("Non-limiting").run()
+    at.selectbox(key="parType_0_filmDiff_comp_1").set_value("Limiting").run()
+
+    assert not at.exception
+    latex = at.session_state.latex_string
+    assert "For component(s)" in latex
+    assert r"i = 1" in latex
+    assert r"i = 2" in latex
+
+
+@pytest.mark.ci
+@pytest.mark.reference
+def test_per_component_advanced_mode_only():
+    """Test that N_c selector appears in advanced_mode without dev_mode."""
+    at = AppTest.from_file("../Equation-Generator.py")
+    at.run()
+    assert not at.exception
+
+    at.selectbox(key="advanced_mode").set_value("On").run()
+    # N_c_choice should be available without dev_mode
+    at.selectbox(key="N_c_choice").set_value(2).run()
+    at.selectbox(key="PSD").set_value("Yes").run()
+    at.selectbox(key="particle_resolution").set_value("1D (radial coordinate)").run()
+    at.selectbox(key="has_binding").set_value("Yes").run()
+
+    # Per-component transport and binding should work
+    at.selectbox(key="parType_0_filmDiff_comp_0").set_value("Limiting").run()
+    at.selectbox(key="parType_0_surfDiff_comp_0").set_value("No").run()
+    at.selectbox(key="parType_0_filmDiff_comp_1").set_value("Non-limiting").run()
+    at.selectbox(key="parType_0_surfDiff_comp_1").set_value("No").run()
+
+    at.selectbox(key="req_binding_comp_0").set_value("Kinetic").run()
+    at.selectbox(key="has_mult_bnd_states_comp_0").set_value("No").run()
+    at.selectbox(key="req_binding_comp_1").set_value("Kinetic").run()
+    at.selectbox(key="has_mult_bnd_states_comp_1").set_value("No").run()
+
+    assert not at.exception
+    latex = at.session_state.latex_string
+    assert "For component(s)" in latex
+
+
+@pytest.mark.ci
+@pytest.mark.reference
+def test_per_component_multi_partype():
+    """Test per-component with multiple particle types (N_p > 1)."""
+    at = AppTest.from_file("../Equation-Generator.py")
+    at.run()
+    assert not at.exception
+
+    at.selectbox(key="advanced_mode").set_value("On").run()
+    at.selectbox(key="dev_mode").set_value("On").run()
+    at.selectbox(key="N_c_choice").set_value(2).run()
+    at.number_input(key=r"N^\mathrm{p}").set_value(2).run()
+    # Both particle types get 1D resolution
+    at.selectbox(key="parType_1_resolution").set_value("1D (radial coordinate)").run()
+    at.selectbox(key="parType_2_resolution").set_value("1D (radial coordinate)").run()
+    at.selectbox(key="has_binding").set_value("Yes").run()
+
+    # Per-component transport for particle type 0
+    at.selectbox(key="parType_0_filmDiff_comp_0").set_value("Limiting").run()
+    at.selectbox(key="parType_0_surfDiff_comp_0").set_value("No").run()
+    at.selectbox(key="parType_0_filmDiff_comp_1").set_value("Non-limiting").run()
+    at.selectbox(key="parType_0_surfDiff_comp_1").set_value("No").run()
+
+    # Per-component transport for particle type 1
+    at.selectbox(key="parType_1_filmDiff_comp_0").set_value("Limiting").run()
+    at.selectbox(key="parType_1_surfDiff_comp_0").set_value("Yes").run()
+    at.selectbox(key="parType_1_filmDiff_comp_1").set_value("Limiting").run()
+    at.selectbox(key="parType_1_surfDiff_comp_1").set_value("No").run()
+
+    # Binding per component within each particle type
+    at.selectbox(key="parType_0_req_binding_comp_0").set_value("Kinetic").run()
+    at.selectbox(key="parType_0_has_mult_bnd_states_comp_0").set_value("No").run()
+    at.selectbox(key="parType_0_req_binding_comp_1").set_value("Kinetic").run()
+    at.selectbox(key="parType_0_has_mult_bnd_states_comp_1").set_value("No").run()
+
+    at.selectbox(key="parType_1_req_binding_comp_0").set_value("Kinetic").run()
+    at.selectbox(key="parType_1_has_mult_bnd_states_comp_0").set_value("No").run()
+    at.selectbox(key="parType_1_req_binding_comp_1").set_value("Kinetic").run()
+    at.selectbox(key="parType_1_has_mult_bnd_states_comp_1").set_value("No").run()
+
+    assert not at.exception
+    latex = at.session_state.latex_string
+    # Different transport across components -> per-component output
     assert "For component(s)" in latex
 
 
@@ -154,9 +319,8 @@ def test_arbitrary_n_c_no_per_component():
     assert not at.exception
 
     at.selectbox(key="advanced_mode").set_value("On").run()
-    at.selectbox(key="dev_mode").set_value("On").run()
     at.selectbox(key="N_c_choice").set_value("Arbitrary").run()
-    at.number_input(key=r"N^\mathrm{p}").set_value(1).run()
+    at.selectbox(key="PSD").set_value("Yes").run()
     at.selectbox(key="has_binding").set_value("Yes").run()
 
     assert not at.exception

--- a/test/test_per_component.py
+++ b/test/test_per_component.py
@@ -8,7 +8,7 @@ from streamlit.testing.v1 import AppTest
 import pytest
 
 
-def setup_grm_with_per_component(at, n_comp, per_comp_settings, n_p=1, use_dev_mode=False):
+def setup_grm_with_per_component(at, n_comp, per_comp_settings, n_p=1):
     """Set up a GRM model with per-component configuration.
 
     Parameters
@@ -22,25 +22,17 @@ def setup_grm_with_per_component(at, n_comp, per_comp_settings, n_p=1, use_dev_m
         'req_binding', 'nonlimiting_filmDiff', 'has_surfDiff', 'has_mult_bnd_states'
     n_p : int
         Number of particle types (default 1).
-    use_dev_mode : bool
-        Whether to enable dev_mode (needed for N_p > 1).
     """
     at.selectbox(key="advanced_mode").set_value("On").run()
-    if use_dev_mode:
-        at.selectbox(key="dev_mode").set_value("On").run()
+    at.selectbox(key="dev_mode").set_value("On").run()
     at.selectbox(key="N_c_choice").set_value(n_comp).run()
-
-    if use_dev_mode:
-        at.number_input(key=r"N^\mathrm{p}").set_value(n_p).run()
-    else:
-        at.selectbox(key="PSD").set_value("Yes").run()
-
+    at.number_input(key=r"N^\mathrm{p}").set_value(n_p).run()
     at.selectbox(key="particle_resolution").set_value("1D (radial coordinate)").run()
     at.selectbox(key="has_binding").set_value("Yes").run()
 
     # Set per-component transport in particle panel (parType_0 for single particle type)
     for i, settings in enumerate(per_comp_settings):
-        film_diff = "Non-limiting" if settings.get('nonlimiting_filmDiff', False) else "Limiting"
+        film_diff = "Yes" if settings.get('nonlimiting_filmDiff', False) else "No"
         at.selectbox(key=f"parType_0_filmDiff_comp_{i}").set_value(film_diff).run()
         if settings.get('has_surfDiff', False) is not False:
             surf_diff = "Yes" if settings['has_surfDiff'] else "No"
@@ -147,14 +139,15 @@ def test_per_component_0d_particle_resolution():
     assert not at.exception
 
     at.selectbox(key="advanced_mode").set_value("On").run()
+    at.selectbox(key="dev_mode").set_value("On").run()
     at.selectbox(key="N_c_choice").set_value(2).run()
-    at.selectbox(key="PSD").set_value("Yes").run()
+    at.number_input(key=r"N^\mathrm{p}").set_value(1).run()
     at.selectbox(key="particle_resolution").set_value("0D (homogeneous)").run()
     at.selectbox(key="has_binding").set_value("Yes").run()
 
     # Film diffusion per component (parType_0 for single particle)
-    at.selectbox(key="parType_0_filmDiff_comp_0").set_value("Limiting").run()
-    at.selectbox(key="parType_0_filmDiff_comp_1").set_value("Limiting").run()
+    at.selectbox(key="parType_0_filmDiff_comp_0").set_value("No").run()
+    at.selectbox(key="parType_0_filmDiff_comp_1").set_value("No").run()
 
     # Binding per component
     at.selectbox(key="req_binding_comp_0").set_value("Kinetic").run()
@@ -186,6 +179,8 @@ def test_per_component_different_film_diffusion():
     assert "For component(s)" in latex
     assert r"i = 1" in latex
     assert r"i = 2" in latex
+    # Bulk equation should also be per-component when film diffusion differs
+    assert "in the interstitial volume" in latex
 
 
 @pytest.mark.ci
@@ -218,13 +213,14 @@ def test_per_component_no_binding_film_diffusion():
     assert not at.exception
 
     at.selectbox(key="advanced_mode").set_value("On").run()
+    at.selectbox(key="dev_mode").set_value("On").run()
     at.selectbox(key="N_c_choice").set_value(2).run()
-    at.selectbox(key="PSD").set_value("Yes").run()
+    at.number_input(key=r"N^\mathrm{p}").set_value(1).run()
     at.selectbox(key="particle_resolution").set_value("1D (radial coordinate)").run()
     at.selectbox(key="has_binding").set_value("No").run()
 
-    at.selectbox(key="parType_0_filmDiff_comp_0").set_value("Non-limiting").run()
-    at.selectbox(key="parType_0_filmDiff_comp_1").set_value("Limiting").run()
+    at.selectbox(key="parType_0_filmDiff_comp_0").set_value("Yes").run()
+    at.selectbox(key="parType_0_filmDiff_comp_1").set_value("No").run()
 
     assert not at.exception
     latex = at.session_state.latex_string
@@ -235,39 +231,8 @@ def test_per_component_no_binding_film_diffusion():
 
 @pytest.mark.ci
 @pytest.mark.reference
-def test_per_component_advanced_mode_only():
-    """Test that N_c selector appears in advanced_mode without dev_mode."""
-    at = AppTest.from_file("../Equation-Generator.py")
-    at.run()
-    assert not at.exception
-
-    at.selectbox(key="advanced_mode").set_value("On").run()
-    # N_c_choice should be available without dev_mode
-    at.selectbox(key="N_c_choice").set_value(2).run()
-    at.selectbox(key="PSD").set_value("Yes").run()
-    at.selectbox(key="particle_resolution").set_value("1D (radial coordinate)").run()
-    at.selectbox(key="has_binding").set_value("Yes").run()
-
-    # Per-component transport and binding should work
-    at.selectbox(key="parType_0_filmDiff_comp_0").set_value("Limiting").run()
-    at.selectbox(key="parType_0_surfDiff_comp_0").set_value("No").run()
-    at.selectbox(key="parType_0_filmDiff_comp_1").set_value("Non-limiting").run()
-    at.selectbox(key="parType_0_surfDiff_comp_1").set_value("No").run()
-
-    at.selectbox(key="req_binding_comp_0").set_value("Kinetic").run()
-    at.selectbox(key="has_mult_bnd_states_comp_0").set_value("No").run()
-    at.selectbox(key="req_binding_comp_1").set_value("Kinetic").run()
-    at.selectbox(key="has_mult_bnd_states_comp_1").set_value("No").run()
-
-    assert not at.exception
-    latex = at.session_state.latex_string
-    assert "For component(s)" in latex
-
-
-@pytest.mark.ci
-@pytest.mark.reference
-def test_per_component_multi_partype():
-    """Test per-component with multiple particle types (N_p > 1)."""
+def test_per_component_multi_partype_mutually_exclusive():
+    """Test that per-component config is disabled when N_p > 1."""
     at = AppTest.from_file("../Equation-Generator.py")
     at.run()
     assert not at.exception
@@ -276,38 +241,12 @@ def test_per_component_multi_partype():
     at.selectbox(key="dev_mode").set_value("On").run()
     at.selectbox(key="N_c_choice").set_value(2).run()
     at.number_input(key=r"N^\mathrm{p}").set_value(2).run()
-    # Both particle types get 1D resolution
-    at.selectbox(key="parType_1_resolution").set_value("1D (radial coordinate)").run()
-    at.selectbox(key="parType_2_resolution").set_value("1D (radial coordinate)").run()
     at.selectbox(key="has_binding").set_value("Yes").run()
-
-    # Per-component transport for particle type 0
-    at.selectbox(key="parType_0_filmDiff_comp_0").set_value("Limiting").run()
-    at.selectbox(key="parType_0_surfDiff_comp_0").set_value("No").run()
-    at.selectbox(key="parType_0_filmDiff_comp_1").set_value("Non-limiting").run()
-    at.selectbox(key="parType_0_surfDiff_comp_1").set_value("No").run()
-
-    # Per-component transport for particle type 1
-    at.selectbox(key="parType_1_filmDiff_comp_0").set_value("Limiting").run()
-    at.selectbox(key="parType_1_surfDiff_comp_0").set_value("Yes").run()
-    at.selectbox(key="parType_1_filmDiff_comp_1").set_value("Limiting").run()
-    at.selectbox(key="parType_1_surfDiff_comp_1").set_value("No").run()
-
-    # Binding per component within each particle type
-    at.selectbox(key="parType_0_req_binding_comp_0").set_value("Kinetic").run()
-    at.selectbox(key="parType_0_has_mult_bnd_states_comp_0").set_value("No").run()
-    at.selectbox(key="parType_0_req_binding_comp_1").set_value("Kinetic").run()
-    at.selectbox(key="parType_0_has_mult_bnd_states_comp_1").set_value("No").run()
-
-    at.selectbox(key="parType_1_req_binding_comp_0").set_value("Kinetic").run()
-    at.selectbox(key="parType_1_has_mult_bnd_states_comp_0").set_value("No").run()
-    at.selectbox(key="parType_1_req_binding_comp_1").set_value("Kinetic").run()
-    at.selectbox(key="parType_1_has_mult_bnd_states_comp_1").set_value("No").run()
 
     assert not at.exception
     latex = at.session_state.latex_string
-    # Different transport across components -> per-component output
-    assert "For component(s)" in latex
+    # Per-component should be disabled when N_p > 1
+    assert "For component(s)" not in latex
 
 
 @pytest.mark.ci
@@ -319,8 +258,9 @@ def test_arbitrary_n_c_no_per_component():
     assert not at.exception
 
     at.selectbox(key="advanced_mode").set_value("On").run()
+    at.selectbox(key="dev_mode").set_value("On").run()
     at.selectbox(key="N_c_choice").set_value("Arbitrary").run()
-    at.selectbox(key="PSD").set_value("Yes").run()
+    at.number_input(key=r"N^\mathrm{p}").set_value(1).run()
     at.selectbox(key="has_binding").set_value("Yes").run()
 
     assert not at.exception


### PR DESCRIPTION
- Adds per-component UI selectboxes for film diffusion and surface diffusion (previously hardcoded to global values)
- Moves per-component configuration outside the binding section so film diffusion is configurable even without binding
- Adds tests for per-component film diffusion, surface diffusion, and the no-binding case

Closes #7