### PR TITLE
Fix tank name and availability badge

### DIFF
--- a/Equation-Generator.py
+++ b/Equation-Generator.py
@@ -312,7 +312,7 @@ if model_type_ == "Crystallization":
     )
 
     if cry_model.column_type == "CSTR":
-        write_and_save(r"Consider a continuously stirred tank reactor (CSTR) with volume $V(t)$, "
+        write_and_save(r"Consider a continuous stirred tank reactor (CSTR) with volume $V(t)$, "
                        r"observed over a time interval $(0, T^{\mathrm{end}})$. "
                        r"The particle population is described by the number density $n(t, x)$ "
                        r"over the internal coordinate (particle size) $x\in(x_0, \infty)$.")
@@ -483,7 +483,7 @@ else: # Chromatography model family
     #%% Continue with model
 
     if column_model.resolution == "0D":
-        intro_str = r"Consider a continuously stirred tank "
+        intro_str = r"Consider a continuous stirred tank "
     elif column_model.column_type == "Radial":
         intro_str = r"Consider a hollow cylindrical column with inner radius $R^{\mathrm{in}} > 0$ and outer radius $R^{\mathrm{out}} > R^{\mathrm{in}}$ "
     elif column_model.column_type == "Frustum":

--- a/src/model_column.py
+++ b/src/model_column.py
@@ -1030,7 +1030,7 @@ class Column:
                 else:
                     model_name = "General " + model_name
             else:
-                return "Continuously Stirred Tank"
+                return "Continuous Stirred Tank"
 
         else:
 

--- a/src/model_column.py
+++ b/src/model_column.py
@@ -466,18 +466,19 @@ class Column:
                 availability = int(availability and p.available_CADET_Core())
                 par1D = par1D or p.resolution == "1D"
                 
-            # no particles with pore diffusion but no film diffusion (yet)
-            if par1D and self.nonlimiting_filmDiff:
+            # no particles with pore diffusion but no film diffusion (yet) but approximation
+            # possible with fast kinetics, expcept for tank where we don't have 1D particles
+            if par1D and self.nonlimiting_filmDiff and not self.resolution == "0D":
                 return 0
         
         # tank model
-        if not self.has_axial_coordinate:
+        if self.resolution == "0D":
             # only 0D particles with non limiting film diffusion available
             if self.N_p > 0:
+                if self.N_p > 1:
+                    return -1
                 if not par1D and self.nonlimiting_filmDiff:
                     return 1
-                elif par1D and not self.nonlimiting_filmDiff: # can be approximated using 1 FV cell
-                    return 0
                 else:
                     return -1
             else:
@@ -553,11 +554,17 @@ class Column:
         if any(p.geometry != "Sphere" for p in self.particle_models):
             return -1
 
-        # tank model
-        if not self.has_axial_coordinate:
+        # tank model: only 0D particles with non limiting film diffusion available
+        if self.resolution == "0D":
             if self.N_p > 0:
-                return -1
-            return 1
+                if self.N_p > 1:
+                    return -1
+                if self.particle_models[0].resolution == "0D" and self.nonlimiting_filmDiff:
+                    return 1
+                else:
+                    return -1
+            else:
+                return 1
 
         availability = 1
 

--- a/test/data/ref_latex/CSTR.tex
+++ b/test/data/ref_latex/CSTR.tex
@@ -20,8 +20,8 @@ Specific model assumptions:
 \end{itemize}
 
 
-\section*{Continuously Stirred Tank}
-Consider a continuously stirred tank filled with a liquid phase, and observed over a time interval $(0, T^{\mathrm{end}})$.
+\section*{Continuous Stirred Tank}
+Consider a continuous stirred tank filled with a liquid phase, and observed over a time interval $(0, T^{\mathrm{end}})$.
 The evolution of the liquid volume $V^{\mathrm{\ell}}\colon (0, T^{\mathrm{end}}) \to \mathbb{R}$ and the concentrations $c_i\colon (0, T^{\mathrm{end}}) \to \mathbb{R}$ of the components in the tank is governed by
 \begin{align}
 

--- a/test/data/ref_latex/CSTR_filter.tex
+++ b/test/data/ref_latex/CSTR_filter.tex
@@ -20,8 +20,8 @@ Specific model assumptions:
 \end{itemize}
 
 
-\section*{Continuously Stirred Tank}
-Consider a continuously stirred tank filled with a liquid phase, and observed over a time interval $(0, T^{\mathrm{end}})$.
+\section*{Continuous Stirred Tank}
+Consider a continuous stirred tank filled with a liquid phase, and observed over a time interval $(0, T^{\mathrm{end}})$.
 The evolution of the liquid volume $V^{\mathrm{\ell}}\colon (0, T^{\mathrm{end}}) \to \mathbb{R}$ and the concentrations $c_i\colon (0, T^{\mathrm{end}}) \to \mathbb{R}$ of the components in the tank is governed by
 \begin{align}
 

--- a/test/data/ref_latex/FiniteBath_w_pores.tex
+++ b/test/data/ref_latex/FiniteBath_w_pores.tex
@@ -30,7 +30,7 @@ Specific model assumptions:
 
 
 \section*{Finite Bath with Pores}
-Consider a continuously stirred tank packed with spherical particles, and observed over a time interval $(0, T^{\mathrm{end}})$.
+Consider a continuous stirred tank packed with spherical particles, and observed over a time interval $(0, T^{\mathrm{end}})$.
 The evolution of the liquid volume $V^{\mathrm{\ell}}\colon (0, T^{\mathrm{end}}) \to \mathbb{R}$ and the concentrations $c_i\colon (0, T^{\mathrm{end}}) \to \mathbb{R}$ of the components in the tank is governed by
 \begin{align}
 

--- a/test/data/ref_latex/FiniteBath_wo_pores.tex
+++ b/test/data/ref_latex/FiniteBath_wo_pores.tex
@@ -31,7 +31,7 @@ Specific model assumptions:
 
 
 \section*{Finite Bath without Pores}
-Consider a continuously stirred tank packed with spherical particles, and observed over a time interval $(0, T^{\mathrm{end}})$.
+Consider a continuous stirred tank packed with spherical particles, and observed over a time interval $(0, T^{\mathrm{end}})$.
 The evolution of the liquid volume $V^{\mathrm{\ell}}\colon (0, T^{\mathrm{end}}) \to \mathbb{R}$ and the concentrations $c_i\colon (0, T^{\mathrm{end}}) \to \mathbb{R}$ of the components in the tank is governed by
 \begin{align}
 

--- a/test/data/ref_latex/GeneralFiniteBath.tex
+++ b/test/data/ref_latex/GeneralFiniteBath.tex
@@ -5,7 +5,7 @@
 \begin{document}
 
 \section*{General Finite Bath}
-Consider a continuously stirred tank packed with spherical particles, and observed over a time interval $(0, T^{\mathrm{end}})$.
+Consider a continuous stirred tank packed with spherical particles, and observed over a time interval $(0, T^{\mathrm{end}})$.
 The evolution of the liquid volume $V^{\mathrm{\ell}}\colon (0, T^{\mathrm{end}}) \to \mathbb{R}$ and the concentrations $c_i\colon (0, T^{\mathrm{end}}) \to \mathbb{R}$ of the components in the tank is governed by
 \begin{align}
 

--- a/test/data/ref_latex/cry_CSTR_Agg_Frag.tex
+++ b/test/data/ref_latex/cry_CSTR_Agg_Frag.tex
@@ -19,7 +19,7 @@ Model assumptions:
 
 \section*{Crystallization in CSTR with nucleation and growth, aggregation, fragmentation}
 The crystallization models stated in the following were established in Zhang et al. (2024) and Zhang et al. (2025).
-Consider a continuously stirred tank reactor (CSTR) with volume $V(t)$, observed over a time interval $(0, T^{\mathrm{end}})$. The particle population is described by the number density $n(t, x)$ over the internal coordinate (particle size) $x\in(x_0, \infty)$.
+Consider a continuous stirred tank reactor (CSTR) with volume $V(t)$, observed over a time interval $(0, T^{\mathrm{end}})$. The particle population is described by the number density $n(t, x)$ over the internal coordinate (particle size) $x\in(x_0, \infty)$.
 The evolution of the number density is governed by the population balance equation
 \begin{align}\frac{\partial (n V)}{\partial t} &= F_{\mathrm{in}} n_{\mathrm{in}} - F_{\mathrm{out}} n - V \left( \frac{\partial (v_G n)}{\partial x} - D_g \frac{\partial^2 n}{\partial x^2} - B_0 \delta(x - x_c) \right) + V \left( B_{\mathrm{agg}} - D_{\mathrm{agg}} \right) + V \left( B_{\mathrm{frag}} - D_{\mathrm{frag}} \right). \end{align}
 with nucleation kinetics and regularity boundary conditions in the internal coordinate

--- a/test/data/ref_latex/cry_CSTR_primaryGrowth.tex
+++ b/test/data/ref_latex/cry_CSTR_primaryGrowth.tex
@@ -16,7 +16,7 @@ Model assumptions:
 
 \section*{Crystallization in CSTR with nucleation and growth}
 The crystallization models stated in the following were established in Zhang et al. (2024) and Zhang et al. (2025).
-Consider a continuously stirred tank reactor (CSTR) with volume $V(t)$, observed over a time interval $(0, T^{\mathrm{end}})$. The particle population is described by the number density $n(t, x)$ over the internal coordinate (particle size) $x\in(x_0, \infty)$.
+Consider a continuous stirred tank reactor (CSTR) with volume $V(t)$, observed over a time interval $(0, T^{\mathrm{end}})$. The particle population is described by the number density $n(t, x)$ over the internal coordinate (particle size) $x\in(x_0, \infty)$.
 The evolution of the number density is governed by the population balance equation
 \begin{align}\frac{\partial (n V)}{\partial t} &= F_{\mathrm{in}} n_{\mathrm{in}} - F_{\mathrm{out}} n - V \left( \frac{\partial (v_G n)}{\partial x} - D_g \frac{\partial^2 n}{\partial x^2} - B_0 \delta(x - x_c) \right). \end{align}
 with nucleation kinetics and regularity boundary conditions in the internal coordinate

--- a/test/test_model_column.py
+++ b/test/test_model_column.py
@@ -434,11 +434,11 @@ class TestColumnSemiAnalyticAvailability:
 
     @pytest.mark.ci
     @pytest.mark.unit_test
-    def test_finite_bath_not_supported(self):
+    def test_general_finite_bath_not_supported(self):
         col = _make_column(
-            has_axial_coordinate=False,
+            resolution="0D",
             N_p=1, has_binding=True,
-            particle_models=[_make_particle(resolution="0D")],
+            particle_models=[_make_particle(resolution="1D")],
         )
         assert col.available_CADET_SemiAnalytic() == -1
 


### PR DESCRIPTION
It should be continuous stirred tank, not continuously.
Also, the availability badge was off.